### PR TITLE
#70 - build: fix cargo dependency problem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ nix = {version = "0.28.0", features = ["feature"]}
 num_enum = "0.7.1"
 page_size = "0.6.0"
 
-[target.'cfg(not(target_env = "macos"))'.dependencies]
+[target.'cfg(not(target_os = "macos"))'.dependencies]
 sysinfo_dot_h = "0.2.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/mu.l
+++ b/mu.l
@@ -1,5 +1,3 @@
-;;; (mu:make-ns :mu-ns)
-
 (define-macro defun (name lambda &rest body)
-  (prelude:warn `',name "name")
-  `(mu:intern () "name" (:lambda lambda body)))
+;;;  (prelude:warn name "name")
+  ())


### PR DESCRIPTION
Make Cargo.toml sysinfo dependency on macos  work correctly

docs: no change
tests: no change
regression: no change
srcs: no change