### PR TITLE
#119 - lib: unified namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ dist/mu-server
 dist/mu-sys
 dist/prelude.l
 doc/rustdoc
-metrics/regression/current.report
+metrics/regression/*.report
 metrics/regression/json
 metrics/valgrind/cachegrind.report
 metrics/valgrind/callgrind.report

--- a/metrics/regression/current.summary
+++ b/metrics/regression/current.summary
@@ -1,40 +1,40 @@
 Perf Metrics Summary: lib
 --------------------
-lib/compile        bytes:     1520     usecs:      34.30
-lib/core           bytes:     5808     usecs:     112.44
-lib/gcd            bytes:      624     usecs:     100.42
-lib/list           bytes:     5296     usecs:      91.84
-lib/namespace      bytes:      240     usecs:       3.24
-lib/number         bytes:     3600     usecs:      61.60
-lib/reader         bytes:     5280     usecs:      82.48
-lib/special-form   bytes:     2400     usecs:      50.38
-lib/stream         bytes:      480     usecs:      10.90
-lib/struct         bytes:      576     usecs:      21.82
-lib/symbol         bytes:     1200     usecs:      21.88
-lib/vector         bytes:     4456     usecs:      89.74
+lib/compile        bytes:     1520     usecs:      35.64
+lib/core           bytes:     5808     usecs:     115.30
+lib/gcd            bytes:      624     usecs:     100.92
+lib/list           bytes:     5296     usecs:      91.60
+lib/namespace      bytes:      240     usecs:       3.30
+lib/number         bytes:     3600     usecs:      61.68
+lib/reader         bytes:     5280     usecs:      84.06
+lib/special-form   bytes:     2400     usecs:      51.90
+lib/stream         bytes:      480     usecs:      10.46
+lib/struct         bytes:      576     usecs:      10.94
+lib/symbol         bytes:     1200     usecs:      21.94
+lib/vector         bytes:     4456     usecs:     112.28
 
 Perf Metrics Summary: frequent
 --------------------
-frequent/core      bytes:     9624     usecs:     469.72
-frequent/fixnum    bytes:     1680     usecs:      29.18
-frequent/float     bytes:     1200     usecs:      21.66
-frequent/list      bytes:     2160     usecs:      38.90
-frequent/vector    bytes:      240     usecs:       5.28
+frequent/core      bytes:     9624     usecs:     462.50
+frequent/fixnum    bytes:     1680     usecs:      27.72
+frequent/float     bytes:     1200     usecs:      21.00
+frequent/list      bytes:     2160     usecs:      37.52
+frequent/vector    bytes:      240     usecs:       4.40
 
 Perf Metrics Summary: prelude
 --------------------
-prelude/closure    bytes:    20904     usecs:   10088.86
-prelude/compile    bytes:     5512     usecs:    1112.18
-prelude/prelude    bytes:     4592     usecs:     212.58
-prelude/exception  bytes:     6896     usecs:    3637.84
-prelude/fixnum     bytes:     2000     usecs:     150.94
-prelude/format     bytes:     6184     usecs:    4998.30
-prelude/lambda     bytes:    97784     usecs:   47899.98
-prelude/list       bytes:    20864     usecs:    6600.78
-prelude/macro      bytes:    58640     usecs:   31580.12
-prelude/reader     bytes:    15216     usecs:   83821.12
-prelude/stream     bytes:      960     usecs:      60.94
-prelude/string     bytes:     2160     usecs:     436.98
-prelude/type       bytes:     8768     usecs:    4469.52
-prelude/vector     bytes:     9472     usecs:    4779.34
+prelude/closure    bytes:    20904     usecs:   10127.34
+prelude/compile    bytes:     5512     usecs:    1112.80
+prelude/prelude    bytes:     4592     usecs:     220.26
+prelude/exception  bytes:     6896     usecs:    3650.80
+prelude/fixnum     bytes:     2000     usecs:     149.62
+prelude/format     bytes:     6184     usecs:    5037.70
+prelude/lambda     bytes:    97784     usecs:   48117.52
+prelude/list       bytes:    20864     usecs:    6517.32
+prelude/macro      bytes:    58640     usecs:   31707.24
+prelude/reader     bytes:    15216     usecs:   84202.62
+prelude/stream     bytes:      960     usecs:      60.38
+prelude/string     bytes:     2160     usecs:     436.12
+prelude/type       bytes:     8768     usecs:    4516.80
+prelude/vector     bytes:     9472     usecs:    4824.42
 

--- a/src/libenv/core/compile.rs
+++ b/src/libenv/core/compile.rs
@@ -49,7 +49,7 @@ impl Compile {
         let lambda = Symbol::keyword("lambda");
 
         let if_vec = vec![
-            env.if_,
+            Namespace::intern_symbol(env, env.lib_ns, "if".to_string(), Tag::nil()),
             Cons::nth(env, 0, args).unwrap(),
             Cons::vlist(env, &[lambda, Tag::nil(), Cons::nth(env, 1, args).unwrap()]),
             Cons::vlist(env, &[lambda, Tag::nil(), Cons::nth(env, 2, args).unwrap()]),

--- a/src/libenv/core/env.rs
+++ b/src/libenv/core/env.rs
@@ -12,14 +12,13 @@ use {
             config::Config,
             exception::{self, Condition, Exception},
             frame::Frame,
-            lib::{Core as _, Lib, LIB},
+            lib::{Lib, LIB},
             namespace::Namespace,
             types::{Tag, Type},
         },
         features::{Core as _, Feature},
         types::{
             cons::{Cons, Core as _},
-            function::Function,
             streambuilder::StreamBuilder,
             symbol::{Core as _, Symbol},
             vector::{Core as _, Vector},
@@ -48,9 +47,6 @@ pub struct Env {
     // ns/async maps
     pub async_index: RwLock<HashMap<u64, Context>>,
     pub ns_index: RwLock<HashMap<u64, (Tag, Namespace)>>,
-
-    // internal functions
-    pub if_: Tag,
 
     // namespaces
     features: Vec<Tag>,
@@ -85,7 +81,6 @@ impl Core for Env {
             features: Vec::new(),
             gc_root: RwLock::new(Vec::<Tag>::new()),
             heap: RwLock::new(BumpAllocator::new(config.npages, Tag::NTYPES)),
-            if_: Tag::nil(),
             keyword_ns: Tag::nil(),
             lexical: RwLock::new(HashMap::new()),
             lib_ns: Tag::nil(),
@@ -140,10 +135,10 @@ impl Core for Env {
         Namespace::intern_symbol(&env, env.lib_ns, "std-out".to_string(), env.stdout);
         Namespace::intern_symbol(&env, env.lib_ns, "err-out".to_string(), env.errout);
 
-        // core functions
-        Self::lib_functions(&env);
-        env.if_ = Function::new(Tag::from(3i64), Symbol::keyword("if")).evict(&env);
+        // lib functions
+        Lib::lib_symbols(&env);
 
+        // features
         env.features = Feature::install_features(&env);
 
         env

--- a/src/libenv/features/mod.rs
+++ b/src/libenv/features/mod.rs
@@ -6,7 +6,7 @@
 use crate::{
     core::{
         env::{Core as _, Env},
-        lib::{Core as _, LibFn},
+        lib::{Core as _, Lib, LibFn},
         namespace::Namespace,
         types::{Tag, Type},
     },
@@ -40,7 +40,7 @@ impl Feature {
             Err(_) => panic!(),
         };
 
-        Env::feature_functions(env, ns, feature.symbols);
+        Lib::feature_symbols(env, ns, feature.symbols);
 
         ns
     }


### PR DESCRIPTION
move the internal if function to lib

docs: no change
tests: no change
regression: ignore base.report
srcs: liob::compile gets to look up the if internal function. doesn't seem to make much difference to performance.