### PR TITLE
#126 - lib: move standard stream bindings into lib

### DIFF
--- a/metrics/regression/current.summary
+++ b/metrics/regression/current.summary
@@ -1,40 +1,40 @@
 Perf Metrics Summary: lib
 --------------------
-lib/compile        bytes:     1520     usecs:      35.64
-lib/core           bytes:     5808     usecs:     115.30
-lib/gcd            bytes:      624     usecs:     100.92
-lib/list           bytes:     5296     usecs:      91.60
-lib/namespace      bytes:      240     usecs:       3.30
-lib/number         bytes:     3600     usecs:      61.68
-lib/reader         bytes:     5280     usecs:      84.06
-lib/special-form   bytes:     2400     usecs:      51.90
-lib/stream         bytes:      480     usecs:      10.46
-lib/struct         bytes:      576     usecs:      10.94
-lib/symbol         bytes:     1200     usecs:      21.94
-lib/vector         bytes:     4456     usecs:     112.28
+lib/compile        bytes:     1520     usecs:      46.08
+lib/core           bytes:     5808     usecs:     146.60
+lib/gcd            bytes:      624     usecs:     140.36
+lib/list           bytes:     5296     usecs:     111.78
+lib/namespace      bytes:      240     usecs:       3.64
+lib/number         bytes:     3600     usecs:      75.76
+lib/reader         bytes:     5280     usecs:      98.82
+lib/special-form   bytes:     2400     usecs:      59.24
+lib/stream         bytes:      480     usecs:      12.64
+lib/struct         bytes:      576     usecs:      14.44
+lib/symbol         bytes:     1200     usecs:      26.66
+lib/vector         bytes:     4456     usecs:      93.80
 
 Perf Metrics Summary: frequent
 --------------------
-frequent/core      bytes:     9624     usecs:     462.50
-frequent/fixnum    bytes:     1680     usecs:      27.72
-frequent/float     bytes:     1200     usecs:      21.00
-frequent/list      bytes:     2160     usecs:      37.52
-frequent/vector    bytes:      240     usecs:       4.40
+frequent/core      bytes:     9624     usecs:     608.00
+frequent/fixnum    bytes:     1680     usecs:      34.10
+frequent/float     bytes:     1200     usecs:      25.66
+frequent/list      bytes:     2160     usecs:      44.32
+frequent/vector    bytes:      240     usecs:       5.40
 
 Perf Metrics Summary: prelude
 --------------------
-prelude/closure    bytes:    20904     usecs:   10127.34
-prelude/compile    bytes:     5512     usecs:    1112.80
-prelude/prelude    bytes:     4592     usecs:     220.26
-prelude/exception  bytes:     6896     usecs:    3650.80
-prelude/fixnum     bytes:     2000     usecs:     149.62
-prelude/format     bytes:     6184     usecs:    5037.70
-prelude/lambda     bytes:    97784     usecs:   48117.52
-prelude/list       bytes:    20864     usecs:    6517.32
-prelude/macro      bytes:    58640     usecs:   31707.24
-prelude/reader     bytes:    15216     usecs:   84202.62
-prelude/stream     bytes:      960     usecs:      60.38
-prelude/string     bytes:     2160     usecs:     436.12
-prelude/type       bytes:     8768     usecs:    4516.80
-prelude/vector     bytes:     9472     usecs:    4824.42
+prelude/closure    bytes:    20904     usecs:   14620.30
+prelude/compile    bytes:     5512     usecs:    1575.88
+prelude/prelude    bytes:     4592     usecs:     266.68
+prelude/exception  bytes:     6896     usecs:    5317.72
+prelude/fixnum     bytes:     2000     usecs:     185.40
+prelude/format     bytes:     6184     usecs:    7193.42
+prelude/lambda     bytes:    97784     usecs:   69028.42
+prelude/list       bytes:    20864     usecs:    8885.20
+prelude/macro      bytes:    58640     usecs:   44247.32
+prelude/reader     bytes:    15216     usecs:  117729.02
+prelude/stream     bytes:      960     usecs:      69.12
+prelude/string     bytes:     2160     usecs:     557.82
+prelude/type       bytes:     8768     usecs:    6198.18
+prelude/vector     bytes:     9472     usecs:    6570.04
 

--- a/src/libenv/lib.rs
+++ b/src/libenv/lib.rs
@@ -61,6 +61,7 @@ use {
         config::Config,
         env::{self, Core},
         exception::{self, Core as _},
+        lib::LIB,
     },
     std::fs,
     streams::{read::Core as _, write::Core as _},
@@ -137,7 +138,11 @@ impl Env {
 
     /// convert a rust String to a tagged s-expression
     pub fn read_str(&self, str: &str) -> exception::Result<Tag> {
-        match StreamBuilder::new().string(str.to_string()).input().build() {
+        match StreamBuilder::new()
+            .string(str.to_string())
+            .input()
+            .build(&LIB)
+        {
             Ok(stream) => self.0.read_stream(stream, true, Tag::nil(), false),
             Err(e) => Err(e),
         }
@@ -155,7 +160,11 @@ impl Env {
 
     /// write a tag to a String
     pub fn write_to_string(&self, expr: Tag, esc: bool) -> String {
-        let str_stream = match StreamBuilder::new().string("".to_string()).output().build() {
+        let str_stream = match StreamBuilder::new()
+            .string("".to_string())
+            .output()
+            .build(&LIB)
+        {
             Ok(stream) => {
                 let str_tag = stream;
 
@@ -170,17 +179,17 @@ impl Env {
 
     /// return the standard-input lib stream
     pub fn std_in(&self) -> Tag {
-        self.0.stdin
+        LIB.stdin()
     }
 
     /// return the standard-output lib stream
     pub fn std_out(&self) -> Tag {
-        self.0.stdout
+        LIB.stdout()
     }
 
     /// return the error-output lib stream
     pub fn err_out(&self) -> Tag {
-        self.0.errout
+        LIB.errout()
     }
 
     // eval &str

--- a/src/libenv/streams/operator.rs
+++ b/src/libenv/streams/operator.rs
@@ -7,7 +7,7 @@ use {
         core::{
             direct::{DirectInfo, DirectTag, DirectType, ExtType},
             exception::{self, Condition, Exception},
-            lib::LIB,
+            lib::{Lib, LIB},
             types::Tag,
         },
         streams::system::{StringDirection, SystemStream, SystemStreamBuilder},
@@ -36,7 +36,7 @@ pub trait Core {
     fn open_input_string(_: &str) -> exception::Result<Tag>;
     fn open_output_string(_: &str) -> exception::Result<Tag>;
     fn open_bidir_string(_: &str) -> exception::Result<Tag>;
-    fn open_std_stream(_: SystemStream) -> exception::Result<Tag>;
+    fn open_std_stream(_: SystemStream, _: &Lib) -> exception::Result<Tag>;
 
     fn get_string(_: &SystemStream) -> Option<String>;
 }
@@ -181,10 +181,10 @@ impl Core for SystemStream {
         Self::open_string(path, StringDirection::Bidir)
     }
 
-    fn open_std_stream(std_stream: SystemStream) -> exception::Result<Tag> {
+    fn open_std_stream(std_stream: SystemStream, lib: &Lib) -> exception::Result<Tag> {
         match std_stream {
             SystemStream::StdInput | SystemStream::StdOutput | SystemStream::StdError => {
-                let mut streams_ref = block_on(LIB.streams.write());
+                let mut streams_ref = block_on(lib.streams.write());
                 let index = streams_ref.len();
 
                 streams_ref.push(RwLock::new(Stream {

--- a/src/libenv/types/streambuilder.rs
+++ b/src/libenv/types/streambuilder.rs
@@ -5,6 +5,7 @@
 use crate::{
     core::{
         exception::{self, Condition, Exception},
+        lib::Lib,
         types::Tag,
     },
     streams::{operator::Core as _, system::SystemStream},
@@ -76,7 +77,7 @@ impl StreamBuilder {
         self
     }
 
-    pub fn build(&self) -> exception::Result<Tag> {
+    pub fn build(&self, lib: &Lib) -> exception::Result<Tag> {
         match &self.file {
             Some(path) => match self.input {
                 Some(_) => SystemStream::open_input_file(path),
@@ -94,11 +95,11 @@ impl StreamBuilder {
                     },
                 },
                 None => match self.stdin {
-                    Some(_) => SystemStream::open_std_stream(SystemStream::StdInput),
+                    Some(_) => SystemStream::open_std_stream(SystemStream::StdInput, lib),
                     None => match self.stdout {
-                        Some(_) => SystemStream::open_std_stream(SystemStream::StdOutput),
+                        Some(_) => SystemStream::open_std_stream(SystemStream::StdOutput, lib),
                         None => match self.errout {
-                            Some(_) => SystemStream::open_std_stream(SystemStream::StdError),
+                            Some(_) => SystemStream::open_std_stream(SystemStream::StdError, lib),
                             None => Err(Exception::new(Condition::Range, "open", Tag::nil())),
                         },
                     },

--- a/src/libenv/types/streams.rs
+++ b/src/libenv/types/streams.rs
@@ -89,9 +89,9 @@ impl LibFunction for Stream {
                     let arg = Vector::as_string(env, st_arg);
 
                     let stream = if st_dir.eq_(&Symbol::keyword("input")) {
-                        StreamBuilder::new().file(arg).input().build()
+                        StreamBuilder::new().file(arg).input().build(&LIB)
                     } else if st_dir.eq_(&Symbol::keyword("output")) {
-                        StreamBuilder::new().file(arg).output().build()
+                        StreamBuilder::new().file(arg).output().build(&LIB)
                     } else {
                         return Err(Exception::new(Condition::Type, "open", st_dir));
                     };
@@ -105,11 +105,11 @@ impl LibFunction for Stream {
                     let arg = Vector::as_string(env, st_arg);
 
                     let stream = if st_dir.eq_(&Symbol::keyword("input")) {
-                        StreamBuilder::new().string(arg).input().build()
+                        StreamBuilder::new().string(arg).input().build(&LIB)
                     } else if st_dir.eq_(&Symbol::keyword("output")) {
-                        StreamBuilder::new().string(arg).output().build()
+                        StreamBuilder::new().string(arg).output().build(&LIB)
                     } else if st_dir.eq_(&Symbol::keyword("bidir")) {
-                        StreamBuilder::new().string(arg).bidir().build()
+                        StreamBuilder::new().string(arg).bidir().build(&LIB)
                     } else {
                         return Err(Exception::new(Condition::Type, "open", st_dir));
                     };


### PR DESCRIPTION
standard streams are now per lib, not per env

docs: no change
tests: no change
regression: small improvment in timings in half a dozen tests
srcs: move all standard stream creation from from Env to Lib