### PR TITLE
#130 - lib: divorce namespace creation from env

### DIFF
--- a/metrics/regression/current.summary
+++ b/metrics/regression/current.summary
@@ -1,40 +1,40 @@
 Perf Metrics Summary: lib
 --------------------
-lib/compile        bytes:     1520     usecs:      43.94
-lib/core           bytes:     5808     usecs:     146.30
-lib/gcd            bytes:      624     usecs:     140.84
-lib/list           bytes:     5296     usecs:     113.28
-lib/namespace      bytes:      240     usecs:       3.82
-lib/number         bytes:     3600     usecs:      75.38
-lib/reader         bytes:     5280     usecs:      93.54
-lib/special-form   bytes:     2400     usecs:      54.12
-lib/stream         bytes:      480     usecs:      11.64
-lib/struct         bytes:      576     usecs:      15.06
-lib/symbol         bytes:     1200     usecs:      24.68
-lib/vector         bytes:     4456     usecs:      89.82
+lib/compile        bytes:     1520     usecs:      45.00
+lib/core           bytes:     5808     usecs:     145.98
+lib/gcd            bytes:      624     usecs:     139.36
+lib/list           bytes:     5296     usecs:     109.98
+lib/namespace      bytes:      240     usecs:       3.44
+lib/number         bytes:     3600     usecs:      72.18
+lib/reader         bytes:     5280     usecs:      94.70
+lib/special-form   bytes:     2400     usecs:      55.90
+lib/stream         bytes:      480     usecs:      12.28
+lib/struct         bytes:      576     usecs:      13.58
+lib/symbol         bytes:     1200     usecs:      26.66
+lib/vector         bytes:     4456     usecs:      93.70
 
 Perf Metrics Summary: frequent
 --------------------
-frequent/core      bytes:     9624     usecs:     603.50
-frequent/fixnum    bytes:     1680     usecs:      33.18
-frequent/float     bytes:     1200     usecs:      25.38
-frequent/list      bytes:     2160     usecs:      42.80
-frequent/vector    bytes:      240     usecs:       4.84
+frequent/core      bytes:     9624     usecs:     620.48
+frequent/fixnum    bytes:     1680     usecs:      36.60
+frequent/float     bytes:     1200     usecs:      27.00
+frequent/list      bytes:     2160     usecs:      47.46
+frequent/vector    bytes:      240     usecs:       5.48
 
 Perf Metrics Summary: prelude
 --------------------
-prelude/closure    bytes:    20904     usecs:   14363.26
-prelude/compile    bytes:     5512     usecs:    1523.60
-prelude/prelude    bytes:     4592     usecs:     266.18
-prelude/exception  bytes:     6896     usecs:    5074.58
-prelude/fixnum     bytes:     2000     usecs:     176.52
-prelude/format     bytes:     6184     usecs:    7102.44
-prelude/lambda     bytes:    97784     usecs:   67439.62
-prelude/list       bytes:    20864     usecs:    8838.78
-prelude/macro      bytes:    58640     usecs:   44136.42
-prelude/reader     bytes:    15216     usecs:  117912.16
-prelude/stream     bytes:      960     usecs:      69.24
-prelude/string     bytes:     2160     usecs:     574.24
-prelude/type       bytes:     8768     usecs:    6236.26
-prelude/vector     bytes:     9472     usecs:    6638.26
+prelude/closure    bytes:    20904     usecs:   14119.52
+prelude/compile    bytes:     5512     usecs:    1515.50
+prelude/prelude    bytes:     4592     usecs:     257.84
+prelude/exception  bytes:     6896     usecs:    5109.56
+prelude/fixnum     bytes:     2000     usecs:     178.86
+prelude/format     bytes:     6184     usecs:    7182.66
+prelude/lambda     bytes:    97784     usecs:   66621.94
+prelude/list       bytes:    20864     usecs:    8947.74
+prelude/macro      bytes:    58640     usecs:   44895.60
+prelude/reader     bytes:    15216     usecs:  125674.24
+prelude/stream     bytes:      960     usecs:      73.28
+prelude/string     bytes:     2160     usecs:     578.28
+prelude/type       bytes:     8768     usecs:    6165.02
+prelude/vector     bytes:     9472     usecs:    6618.20
 

--- a/src/libenv/core/env.rs
+++ b/src/libenv/core/env.rs
@@ -13,7 +13,7 @@ use {
             exception::{self, Condition, Exception},
             frame::Frame,
             lib::Lib,
-            namespace::Namespace,
+            namespace::{Namespace, NsRwLockIndex},
             types::{Tag, Type},
         },
         types::{
@@ -43,7 +43,7 @@ pub struct Env {
 
     // ns/async maps
     pub async_index: RwLock<HashMap<u64, Context>>,
-    pub ns_index: RwLock<HashMap<u64, (Tag, Namespace)>>,
+    pub ns_index: NsRwLockIndex,
 
     // namespaces
     pub keyword_ns: Tag,

--- a/src/libenv/core/lib.rs
+++ b/src/libenv/core/lib.rs
@@ -18,7 +18,7 @@ use {
             frame::{Frame, LibFunction as _},
             gc::{Gc, LibFunction as _},
             heap::{Heap, LibFunction as _},
-            namespace::{LibFunction as _, Namespace},
+            namespace::{LibFunction as _, Namespace, NsRwLockMap},
             types::{LibFunction as _, Tag},
             utime::LibFunction as _,
         },
@@ -152,13 +152,14 @@ lazy_static! {
 pub struct Lib {
     pub version: &'static str,
 
-    pub heap: RwLock<BumpAllocator>,
-    pub symbols: RwLock<HashMap<String, Tag>>,
-    pub functions: RwLock<HashMap<u64, LibFn>>,
-    pub features: RwLock<Vec<Feature>>,
-    pub streams: RwLock<Vec<RwLock<Stream>>>,
     pub eol: Tag,
+    pub features: RwLock<Vec<Feature>>,
+    pub functions: RwLock<HashMap<u64, LibFn>>,
+    pub heap: RwLock<BumpAllocator>,
+    pub ns_index: RwLock<HashMap<u64, (Tag, Namespace)>>,
     pub stdio: RwLock<(Tag, Tag, Tag)>,
+    pub streams: RwLock<Vec<RwLock<Stream>>>,
+    pub symbols: NsRwLockMap,
 }
 
 impl Lib {
@@ -170,6 +171,7 @@ impl Lib {
             features: RwLock::new(Vec::new()),
             functions: RwLock::new(HashMap::new()),
             heap: RwLock::new(BumpAllocator::new(10, Tag::NTYPES)),
+            ns_index: RwLock::new(HashMap::new()),
             stdio: RwLock::new((Tag::nil(), Tag::nil(), Tag::nil())),
             streams: RwLock::new(Vec::new()),
             symbols: RwLock::new(HashMap::new()),


### PR DESCRIPTION
interfaces for envless indices, add some types

docs: no change
tests: no change
regression: no change
srcs: augment namespace types and use them, add register_ functions