### PR TITLE
#142 - lib: futures with tags

### DIFF
--- a/metrics/regression/current.summary
+++ b/metrics/regression/current.summary
@@ -1,40 +1,40 @@
 Perf Metrics Summary: lib
 --------------------
-lib/compile        bytes:     1520     usecs:      53.58
-lib/core           bytes:     5808     usecs:     161.22
-lib/gcd            bytes:      624     usecs:     144.24
-lib/list           bytes:     5296     usecs:     118.04
-lib/namespace      bytes:      240     usecs:       3.94
-lib/number         bytes:     3600     usecs:      80.54
-lib/reader         bytes:     5280     usecs:     104.98
-lib/special-form   bytes:     2400     usecs:      61.72
-lib/stream         bytes:      480     usecs:      13.24
-lib/struct         bytes:      576     usecs:      13.64
-lib/symbol         bytes:     1200     usecs:      27.90
-lib/vector         bytes:     4456     usecs:     101.56
+lib/compile        bytes:     1520     usecs:      48.82
+lib/core           bytes:     5808     usecs:     151.36
+lib/gcd            bytes:      624     usecs:     143.44
+lib/list           bytes:     5296     usecs:     119.10
+lib/namespace      bytes:      240     usecs:       4.02
+lib/number         bytes:     3600     usecs:      80.50
+lib/reader         bytes:     5280     usecs:     104.36
+lib/special-form   bytes:     2400     usecs:      60.68
+lib/stream         bytes:      480     usecs:      12.88
+lib/struct         bytes:      576     usecs:      13.54
+lib/symbol         bytes:     1200     usecs:      28.76
+lib/vector         bytes:     4456     usecs:     100.36
 
 Perf Metrics Summary: frequent
 --------------------
-frequent/core      bytes:     9624     usecs:     637.98
-frequent/fixnum    bytes:     1680     usecs:      36.70
+frequent/core      bytes:     9624     usecs:     636.00
+frequent/fixnum    bytes:     1680     usecs:      37.08
 frequent/float     bytes:     1200     usecs:      27.12
-frequent/list      bytes:     2160     usecs:      46.74
-frequent/vector    bytes:      240     usecs:       5.36
+frequent/list      bytes:     2160     usecs:      47.50
+frequent/vector    bytes:      240     usecs:       5.38
 
 Perf Metrics Summary: prelude
 --------------------
-prelude/closure    bytes:    20904     usecs:   14416.16
-prelude/compile    bytes:     5512     usecs:    1531.98
-prelude/prelude    bytes:     4592     usecs:     255.30
-prelude/exception  bytes:     6896     usecs:    5332.82
-prelude/fixnum     bytes:     2000     usecs:     176.66
-prelude/format     bytes:     6184     usecs:    7256.24
-prelude/lambda     bytes:    97784     usecs:   67972.40
-prelude/list       bytes:    20864     usecs:    8941.12
-prelude/macro      bytes:    58640     usecs:   43857.70
-prelude/reader     bytes:    15216     usecs:  117449.82
-prelude/stream     bytes:      960     usecs:      66.28
-prelude/string     bytes:     2160     usecs:     547.88
-prelude/type       bytes:     8768     usecs:    6164.96
-prelude/vector     bytes:     9472     usecs:    6794.26
+prelude/closure    bytes:    20904     usecs:   14568.96
+prelude/compile    bytes:     5512     usecs:    1570.06
+prelude/prelude    bytes:     4592     usecs:     269.30
+prelude/exception  bytes:     6896     usecs:    5200.42
+prelude/fixnum     bytes:     2000     usecs:     184.80
+prelude/format     bytes:     6184     usecs:    7046.12
+prelude/lambda     bytes:    97784     usecs:   66855.34
+prelude/list       bytes:    20864     usecs:    9010.64
+prelude/macro      bytes:    58640     usecs:   45224.56
+prelude/reader     bytes:    15216     usecs:  123656.44
+prelude/stream     bytes:      960     usecs:      71.18
+prelude/string     bytes:     2160     usecs:     595.90
+prelude/type       bytes:     8768     usecs:    6339.44
+prelude/vector     bytes:     9472     usecs:    6655.54
 

--- a/src/libenv/core/lib.rs
+++ b/src/libenv/core/lib.rs
@@ -81,10 +81,9 @@ lazy_static! {
         ( "frames",  0, Env::lib_frames ),
         ( "fix",     2, Env::lib_fix ),
         // futures
-        ( "fwait",   1, Futures::lib_fwait ),
+        ( "fwait",   1, Futures::lib_future_wait ),
         ( "future",  2, Futures::lib_future ),
-        ( "fdone",   1, Futures::lib_fcomplete ),
-        ( "ftest",   0, Futures::lib_ftest ),
+        ( "fdone",   1, Futures::lib_future_complete ),
         // exceptions
         ( "with-ex", 2, Exception::lib_with_ex ),
         ( "raise",   2, Exception::lib_raise ),
@@ -156,11 +155,12 @@ pub struct Lib {
     pub eol: Tag,
     pub features: RwLock<Vec<Feature>>,
     pub functions: RwLock<HashMap<u64, LibFn>>,
-    pub futures: RwLock<Vec<std::thread::JoinHandle<Tag>>>,
-    pub threads: FuturePool,
+    pub future_id: RwLock<u64>,
+    pub futures: RwLock<HashMap<u64, std::thread::JoinHandle<Tag>>>,
     pub stdio: RwLock<(Tag, Tag, Tag)>,
     pub streams: RwLock<Vec<RwLock<Stream>>>,
     pub symbols: NsRwLockMap,
+    pub threads: FuturePool,
 }
 
 impl Lib {
@@ -171,14 +171,14 @@ impl Lib {
             eol: DirectTag::to_direct(0, DirectInfo::Length(0), DirectType::Keyword),
             features: RwLock::new(Vec::new()),
             functions: RwLock::new(HashMap::new()),
-            futures: RwLock::new(Vec::new()),
+            future_id: RwLock::new(0),
+            futures: RwLock::new(HashMap::new()),
             threads: FuturePool::new(),
             stdio: RwLock::new((Tag::nil(), Tag::nil(), Tag::nil())),
             streams: RwLock::new(Vec::new()),
             symbols: RwLock::new(HashMap::new()),
             version: Self::VERSION,
         };
-
         let mut functions = block_on(lib.functions.write());
 
         // native functions


### PR DESCRIPTION
now with tags instead of i32

docs: no change
tests: no change
regression: no change
srcs: change how LIB caches futures completion threads