### PR TITLE
#144 - lib: split native function table from lib.rs

### DIFF
--- a/metrics/regression/current.summary
+++ b/metrics/regression/current.summary
@@ -1,40 +1,40 @@
 Perf Metrics Summary: lib
 --------------------
-lib/compile        bytes:     1520     usecs:      48.82
-lib/core           bytes:     5808     usecs:     151.36
-lib/gcd            bytes:      624     usecs:     143.44
-lib/list           bytes:     5296     usecs:     119.10
-lib/namespace      bytes:      240     usecs:       4.02
-lib/number         bytes:     3600     usecs:      80.50
-lib/reader         bytes:     5280     usecs:     104.36
-lib/special-form   bytes:     2400     usecs:      60.68
-lib/stream         bytes:      480     usecs:      12.88
-lib/struct         bytes:      576     usecs:      13.54
-lib/symbol         bytes:     1200     usecs:      28.76
-lib/vector         bytes:     4456     usecs:     100.36
+lib/compile        bytes:     1520     usecs:      50.70
+lib/core           bytes:     5808     usecs:     164.10
+lib/gcd            bytes:      624     usecs:      97.80
+lib/list           bytes:     5296     usecs:      98.50
+lib/namespace      bytes:      240     usecs:       3.34
+lib/number         bytes:     3600     usecs:      64.00
+lib/reader         bytes:     5280     usecs:      85.34
+lib/special-form   bytes:     2400     usecs:      52.02
+lib/stream         bytes:      480     usecs:      11.22
+lib/struct         bytes:      576     usecs:      25.52
+lib/symbol         bytes:     1200     usecs:      23.46
+lib/vector         bytes:     4456     usecs:      86.30
 
 Perf Metrics Summary: frequent
 --------------------
-frequent/core      bytes:     9624     usecs:     636.00
-frequent/fixnum    bytes:     1680     usecs:      37.08
-frequent/float     bytes:     1200     usecs:      27.12
-frequent/list      bytes:     2160     usecs:      47.50
-frequent/vector    bytes:      240     usecs:       5.38
+frequent/core      bytes:     9624     usecs:     466.62
+frequent/fixnum    bytes:     1680     usecs:      29.32
+frequent/float     bytes:     1200     usecs:      21.42
+frequent/list      bytes:     2160     usecs:      37.86
+frequent/vector    bytes:      240     usecs:       4.46
 
 Perf Metrics Summary: prelude
 --------------------
-prelude/closure    bytes:    20904     usecs:   14568.96
-prelude/compile    bytes:     5512     usecs:    1570.06
-prelude/prelude    bytes:     4592     usecs:     269.30
-prelude/exception  bytes:     6896     usecs:    5200.42
-prelude/fixnum     bytes:     2000     usecs:     184.80
-prelude/format     bytes:     6184     usecs:    7046.12
-prelude/lambda     bytes:    97784     usecs:   66855.34
-prelude/list       bytes:    20864     usecs:    9010.64
-prelude/macro      bytes:    58640     usecs:   45224.56
-prelude/reader     bytes:    15216     usecs:  123656.44
-prelude/stream     bytes:      960     usecs:      71.18
-prelude/string     bytes:     2160     usecs:     595.90
-prelude/type       bytes:     8768     usecs:    6339.44
-prelude/vector     bytes:     9472     usecs:    6655.54
+prelude/closure    bytes:    20904     usecs:   10092.72
+prelude/compile    bytes:     5512     usecs:    1105.64
+prelude/prelude    bytes:     4592     usecs:     214.74
+prelude/exception  bytes:     6896     usecs:    3635.06
+prelude/fixnum     bytes:     2000     usecs:     147.44
+prelude/format     bytes:     6184     usecs:    4984.94
+prelude/lambda     bytes:    97784     usecs:   47562.08
+prelude/list       bytes:    20864     usecs:    6463.20
+prelude/macro      bytes:    58640     usecs:   31557.58
+prelude/reader     bytes:    15216     usecs:   83136.82
+prelude/stream     bytes:      960     usecs:      60.16
+prelude/string     bytes:     2160     usecs:     432.12
+prelude/type       bytes:     8768     usecs:    4466.96
+prelude/vector     bytes:     9472     usecs:    4756.42
 

--- a/src/libenv/core/functions.rs
+++ b/src/libenv/core/functions.rs
@@ -1,0 +1,132 @@
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-License-Identifier: MIT
+
+//! lib functions
+use crate::{
+    core::{
+        apply::LibFunction as _,
+        compile::{Compile, LibFunction as _},
+        dynamic::LibFunction as _,
+        env::Env,
+        exception::{self, Exception, LibFunction as _},
+        frame::{Frame, LibFunction as _},
+        futures::Futures,
+        futures::LibFunction as _,
+        gc::{Gc, LibFunction as _},
+        heap::{Heap, LibFunction as _},
+        namespace::{LibFunction as _, Namespace},
+        types::{LibFunction as _, Tag},
+        utime::LibFunction as _,
+    },
+    streams::{read::LibFunction as _, write::LibFunction as _},
+    types::{
+        cons::{Cons, LibFunction as _},
+        fixnum::{Fixnum, LibFunction as _},
+        float::{Float, LibFunction as _},
+        stream::Stream,
+        streams::LibFunction as _,
+        struct_::{LibFunction as _, Struct},
+        symbol::{LibFunction as _, Symbol},
+        vector::{LibFunction as _, Vector},
+    },
+};
+
+pub type LibFn = fn(&Env, &mut Frame) -> exception::Result<()>;
+pub type LibFnDef = (&'static str, u16, LibFn);
+
+lazy_static! {
+    pub static ref LIB_SYMBOLS: Vec<LibFnDef> = vec![
+        // types
+        ( "eq",      2, Tag::lib_eq ),
+        ( "type-of", 1, Tag::lib_typeof ),
+        ( "repr",    2, Tag::lib_repr ),
+        ( "view",    1, Tag::lib_view ),
+        // conses and lists
+        ( "append",  2, Cons::lib_append ),
+        ( "car",     1, Cons::lib_car ),
+        ( "cdr",     1, Cons::lib_cdr ),
+        ( "cons",    2, Cons::lib_cons ),
+        ( "length",  1, Cons::lib_length ),
+        ( "nth",     2, Cons::lib_nth ),
+        ( "nthcdr",  2, Cons::lib_nthcdr ),
+        // compiler
+        ( "compile", 1, Compile::lib_compile ),
+        // gc
+        ( "gc",      0, Gc::lib_gc ),
+        // heap
+        ( "hp-info", 0, Heap::lib_hp_info ),
+        ( "hp-stat", 0, Heap::lib_hp_stat ),
+        ( "hp-size", 1, Heap::lib_hp_size ),
+        // env
+        ( "apply",   2, Env::lib_apply ),
+        ( "eval",    1, Env::lib_eval ),
+        ( "frames",  0, Env::lib_frames ),
+        ( "fix",     2, Env::lib_fix ),
+        // futures
+        ( "fwait",   1, Futures::lib_future_wait ),
+        ( "future",  2, Futures::lib_future ),
+        ( "fdone",   1, Futures::lib_future_complete ),
+        // exceptions
+        ( "with-ex", 2, Exception::lib_with_ex ),
+        ( "raise",   2, Exception::lib_raise ),
+        // frames
+        ( "fr-pop",  1, Frame::lib_fr_pop ),
+        ( "fr-push", 1, Frame::lib_fr_push ),
+        ( "fr-ref",  2, Frame::lib_fr_ref ),
+        // fixnums
+        ( "ash",     2, Fixnum::lib_ash ),
+        ( "fx-add",  2, Fixnum::lib_fxadd ),
+        ( "fx-sub",  2, Fixnum::lib_fxsub ),
+        ( "fx-lt",   2, Fixnum::lib_fxlt ),
+        ( "fx-mul",  2, Fixnum::lib_fxenvl ),
+        ( "fx-div",  2, Fixnum::lib_fxdiv ),
+        ( "logand",  2, Fixnum::lib_logand ),
+        ( "logor",   2, Fixnum::lib_logor ),
+        ( "lognot",  1, Fixnum::lib_lognot ),
+        // floats
+        ( "fl-add",  2, Float::lib_fladd ),
+        ( "fl-sub",  2, Float::lib_flsub ),
+        ( "fl-lt",   2, Float::lib_fllt ),
+        ( "fl-mul",  2, Float::lib_flenvl ),
+        ( "fl-div",  2, Float::lib_fldiv ),
+        // namespaces
+        ( "intern",  3, Namespace::lib_intern ),
+        ( "make-ns", 1, Namespace::lib_make_ns ),
+        ( "ns-find", 2, Namespace::lib_ns_find ),
+        ( "ns-map",  0, Namespace::lib_ns_map ),
+        ( "ns-syms", 2, Namespace::lib_ns_symbols ),
+        ( "unbound", 2, Namespace::lib_unbound ),
+        // read/write
+        ( "read",    3, Env::lib_read ),
+        ( "write",   3, Env::lib_write ),
+        // symbols
+        ( "boundp",  1, Symbol::lib_boundp ),
+        ( "keyword", 1, Symbol::lib_keyword ),
+        ( "symbol",  1, Symbol::lib_symbol ),
+        ( "sy-name", 1, Symbol::lib_name ),
+        ( "sy-ns",   1, Symbol::lib_ns ),
+        ( "sy-val",  1, Symbol::lib_value ),
+        // simple vectors
+        ( "vector",  2, Vector::lib_make_vector ),
+        ( "sv-len",  1, Vector::lib_length ),
+        ( "sv-ref",  2, Vector::lib_svref ),
+        ( "sv-type", 1, Vector::lib_type ),
+        // structs
+        ( "struct",  2, Struct::lib_make_struct ),
+        ( "st-type", 1, Struct::lib_struct_type ),
+        ( "st-vec",  1, Struct::lib_struct_vector ),
+        // streams
+        ( "close",   1, Stream::lib_close ),
+        ( "flush",   1, Stream::lib_flush ),
+        ( "get-str", 1, Stream::lib_get_string ),
+        ( "open",    3, Stream::lib_open ),
+        ( "openp",   1, Stream::lib_openp ),
+        ( "rd-byte", 3, Stream::lib_read_byte ),
+        ( "rd-char", 3, Stream::lib_read_char ),
+        ( "un-char", 2, Stream::lib_unread_char ),
+        ( "wr-byte", 2, Stream::lib_write_byte ),
+        ( "wr-char", 2, Stream::lib_write_char ),
+        // utime
+        ( "utime",   0, Env::lib_utime ),
+    ];
+}

--- a/src/libenv/core/lib.rs
+++ b/src/libenv/core/lib.rs
@@ -5,37 +5,22 @@
 use {
     crate::{
         core::{
-            apply::LibFunction as _,
             compile::{Compile, LibFunction as _},
             direct::{DirectInfo, DirectTag, DirectType},
-            dynamic::LibFunction as _,
             env::Env,
-            exception::{self, Exception, LibFunction as _},
-            frame::{Frame, LibFunction as _},
-            futures::LibFunction as _,
-            futures::{FuturePool, Futures},
-            gc::{Gc, LibFunction as _},
-            heap::{Heap, LibFunction as _},
-            namespace::{LibFunction as _, Namespace, NsRwLockMap},
-            types::{LibFunction as _, Tag},
-            utime::LibFunction as _,
+            functions::{LibFn, LIB_SYMBOLS},
+            futures::FuturePool,
+            namespace::{Namespace, NsRwLockMap},
+            types::Tag,
         },
         features::{Core as _, Feature},
-        streams::{
-            read::LibFunction as _,
-            write::{Core as _, LibFunction as _},
-        },
+        streams::write::Core as _,
         types::{
-            cons::{Cons, LibFunction as _},
-            fixnum::{Fixnum, LibFunction as _},
-            float::{Float, LibFunction as _},
             function::Function,
             stream::Stream,
             streambuilder::StreamBuilder,
-            streams::LibFunction as _,
-            struct_::{LibFunction as _, Struct},
-            symbol::{Core as _, LibFunction as _, Symbol, UNBOUND},
-            vector::{Core as _, LibFunction as _, Vector},
+            symbol::{Core as _, Symbol, UNBOUND},
+            vector::{Core as _, Vector},
         },
     },
     std::collections::HashMap,
@@ -44,109 +29,6 @@ use {futures::executor::block_on, futures_locks::RwLock};
 
 lazy_static! {
     pub static ref LIB: Lib = Lib::new().features().stdio();
-}
-
-//
-// native functions
-//
-pub type LibFn = fn(&Env, &mut Frame) -> exception::Result<()>;
-pub type LibFnDef = (&'static str, u16, LibFn);
-
-lazy_static! {
-    static ref LIB_SYMBOLS: Vec<LibFnDef> = vec![
-        // types
-        ( "eq",      2, Tag::lib_eq ),
-        ( "type-of", 1, Tag::lib_typeof ),
-        ( "repr",    2, Tag::lib_repr ),
-        ( "view",    1, Tag::lib_view ),
-        // conses and lists
-        ( "append",  2, Cons::lib_append ),
-        ( "car",     1, Cons::lib_car ),
-        ( "cdr",     1, Cons::lib_cdr ),
-        ( "cons",    2, Cons::lib_cons ),
-        ( "length",  1, Cons::lib_length ),
-        ( "nth",     2, Cons::lib_nth ),
-        ( "nthcdr",  2, Cons::lib_nthcdr ),
-        // compiler
-        ( "compile", 1, Compile::lib_compile ),
-        // gc
-        ( "gc",      0, Gc::lib_gc ),
-        // heap
-        ( "hp-info", 0, Heap::lib_hp_info ),
-        ( "hp-stat", 0, Heap::lib_hp_stat ),
-        ( "hp-size", 1, Heap::lib_hp_size ),
-        // env
-        ( "apply",   2, Env::lib_apply ),
-        ( "eval",    1, Env::lib_eval ),
-        ( "frames",  0, Env::lib_frames ),
-        ( "fix",     2, Env::lib_fix ),
-        // futures
-        ( "fwait",   1, Futures::lib_future_wait ),
-        ( "future",  2, Futures::lib_future ),
-        ( "fdone",   1, Futures::lib_future_complete ),
-        // exceptions
-        ( "with-ex", 2, Exception::lib_with_ex ),
-        ( "raise",   2, Exception::lib_raise ),
-        // frames
-        ( "fr-pop",  1, Frame::lib_fr_pop ),
-        ( "fr-push", 1, Frame::lib_fr_push ),
-        ( "fr-ref",  2, Frame::lib_fr_ref ),
-        // fixnums
-        ( "ash",     2, Fixnum::lib_ash ),
-        ( "fx-add",  2, Fixnum::lib_fxadd ),
-        ( "fx-sub",  2, Fixnum::lib_fxsub ),
-        ( "fx-lt",   2, Fixnum::lib_fxlt ),
-        ( "fx-mul",  2, Fixnum::lib_fxenvl ),
-        ( "fx-div",  2, Fixnum::lib_fxdiv ),
-        ( "logand",  2, Fixnum::lib_logand ),
-        ( "logor",   2, Fixnum::lib_logor ),
-        ( "lognot",  1, Fixnum::lib_lognot ),
-        // floats
-        ( "fl-add",  2, Float::lib_fladd ),
-        ( "fl-sub",  2, Float::lib_flsub ),
-        ( "fl-lt",   2, Float::lib_fllt ),
-        ( "fl-mul",  2, Float::lib_flenvl ),
-        ( "fl-div",  2, Float::lib_fldiv ),
-        // namespaces
-        ( "intern",  3, Namespace::lib_intern ),
-        ( "make-ns", 1, Namespace::lib_make_ns ),
-        ( "ns-find", 2, Namespace::lib_ns_find ),
-        ( "ns-map",  0, Namespace::lib_ns_map ),
-        ( "ns-syms", 2, Namespace::lib_ns_symbols ),
-        ( "unbound", 2, Namespace::lib_unbound ),
-        // read/write
-        ( "read",    3, Env::lib_read ),
-        ( "write",   3, Env::lib_write ),
-        // symbols
-        ( "boundp",  1, Symbol::lib_boundp ),
-        ( "keyword", 1, Symbol::lib_keyword ),
-        ( "symbol",  1, Symbol::lib_symbol ),
-        ( "sy-name", 1, Symbol::lib_name ),
-        ( "sy-ns",   1, Symbol::lib_ns ),
-        ( "sy-val",  1, Symbol::lib_value ),
-        // simple vectors
-        ( "vector",  2, Vector::lib_make_vector ),
-        ( "sv-len",  1, Vector::lib_length ),
-        ( "sv-ref",  2, Vector::lib_svref ),
-        ( "sv-type", 1, Vector::lib_type ),
-        // structs
-        ( "struct",  2, Struct::lib_make_struct ),
-        ( "st-type", 1, Struct::lib_struct_type ),
-        ( "st-vec",  1, Struct::lib_struct_vector ),
-        // streams
-        ( "close",   1, Stream::lib_close ),
-        ( "flush",   1, Stream::lib_flush ),
-        ( "get-str", 1, Stream::lib_get_string ),
-        ( "open",    3, Stream::lib_open ),
-        ( "openp",   1, Stream::lib_openp ),
-        ( "rd-byte", 3, Stream::lib_read_byte ),
-        ( "rd-char", 3, Stream::lib_read_char ),
-        ( "un-char", 2, Stream::lib_unread_char ),
-        ( "wr-byte", 2, Stream::lib_write_byte ),
-        ( "wr-char", 2, Stream::lib_write_char ),
-        // utime
-        ( "utime",   0, Env::lib_utime ),
-    ];
 }
 
 pub struct Lib {

--- a/src/libenv/core/mod.rs
+++ b/src/libenv/core/mod.rs
@@ -11,6 +11,7 @@ pub mod dynamic;
 pub mod env;
 pub mod exception;
 pub mod frame;
+pub mod functions;
 pub mod futures;
 pub mod gc;
 pub mod heap;

--- a/src/libenv/features/mod.rs
+++ b/src/libenv/features/mod.rs
@@ -2,7 +2,7 @@
 //  SPDX-License-Identifier: MIT
 
 //! features module
-use crate::core::lib::LibFn;
+use crate::core::functions::LibFn;
 
 #[cfg(feature = "nix")]
 use crate::features::nix::nix_::{Core as _, Nix};

--- a/src/libenv/features/nix/nix_.rs
+++ b/src/libenv/features/nix/nix_.rs
@@ -7,7 +7,7 @@ use crate::{
         env::Env,
         exception::{self, Condition, Exception},
         frame::Frame,
-        lib::LibFnDef,
+        functions::LibFnDef,
         types::Tag,
     },
     features::Feature,

--- a/src/libenv/features/std/std_.rs
+++ b/src/libenv/features/std/std_.rs
@@ -8,7 +8,7 @@ use crate::{
         env::Env,
         exception::{self, Condition, Exception},
         frame::Frame,
-        lib::LibFnDef,
+        functions::LibFnDef,
         types::Type,
     },
     features::Feature,

--- a/src/libenv/features/sysinfo/sysinfo_.rs
+++ b/src/libenv/features/sysinfo/sysinfo_.rs
@@ -7,7 +7,7 @@ use crate::{
         env::Env,
         exception::{self, Condition, Exception},
         frame::Frame,
-        lib::LibFnDef,
+        functions::LibFnDef,
         types::Tag,
     },
     features::Feature,


### PR DESCRIPTION
put the lib native function tables in a separate file

docs: no change
tests: no change
regression: no change
srcs: split core/lib.rs into two files