### PR TITLE
#169 - lib: clean up future stack

### DIFF
--- a/metrics/regression/current.summary
+++ b/metrics/regression/current.summary
@@ -1,40 +1,40 @@
 Perf Metrics Summary: lib
 --------------------
-lib/compile        bytes:     1520     usecs:      50.46
-lib/core           bytes:     5808     usecs:     155.98
-lib/gcd            bytes:      624     usecs:     143.72
-lib/list           bytes:     5296     usecs:     117.04
-lib/namespace      bytes:      240     usecs:       3.94
-lib/number         bytes:     3600     usecs:      79.08
-lib/reader         bytes:     5280     usecs:     102.50
-lib/special-form   bytes:     2400     usecs:      60.00
-lib/stream         bytes:      480     usecs:      12.96
-lib/struct         bytes:      576     usecs:      13.26
-lib/symbol         bytes:     1200     usecs:      27.82
-lib/vector         bytes:     4456     usecs:     100.44
+lib/compile        bytes:     1520     usecs:      38.18
+lib/core           bytes:     5808     usecs:     137.68
+lib/gcd            bytes:      624     usecs:      98.48
+lib/list           bytes:     5296     usecs:     102.72
+lib/namespace      bytes:      240     usecs:       3.38
+lib/number         bytes:     3600     usecs:      64.16
+lib/reader         bytes:     5280     usecs:      88.02
+lib/special-form   bytes:     2400     usecs:      51.10
+lib/stream         bytes:      480     usecs:      11.18
+lib/struct         bytes:      576     usecs:      12.14
+lib/symbol         bytes:     1200     usecs:      24.08
+lib/vector         bytes:     4456     usecs:      90.50
 
 Perf Metrics Summary: frequent
 --------------------
-frequent/core      bytes:     9624     usecs:     635.02
-frequent/fixnum    bytes:     1680     usecs:      36.52
-frequent/float     bytes:     1200     usecs:      26.84
-frequent/list      bytes:     2160     usecs:      46.82
-frequent/vector    bytes:      240     usecs:       5.44
+frequent/core      bytes:     9624     usecs:     478.36
+frequent/fixnum    bytes:     1680     usecs:      29.66
+frequent/float     bytes:     1200     usecs:      21.46
+frequent/list      bytes:     2160     usecs:      40.36
+frequent/vector    bytes:      240     usecs:       5.18
 
 Perf Metrics Summary: prelude
 --------------------
-prelude/closure    bytes:    20904     usecs:   14064.30
-prelude/compile    bytes:     5512     usecs:    1526.74
-prelude/prelude    bytes:     4592     usecs:     263.94
-prelude/exception  bytes:     6896     usecs:    5123.08
-prelude/fixnum     bytes:     2000     usecs:     186.34
-prelude/format     bytes:     6184     usecs:    7080.94
-prelude/lambda     bytes:    97784     usecs:   67833.12
-prelude/list       bytes:    20864     usecs:    9021.78
-prelude/macro      bytes:    58640     usecs:   44043.68
-prelude/reader     bytes:    15216     usecs:  118794.86
-prelude/stream     bytes:      960     usecs:      68.82
-prelude/string     bytes:     2160     usecs:     562.12
-prelude/type       bytes:     8768     usecs:    6064.54
-prelude/vector     bytes:     9472     usecs:    6578.82
+prelude/closure    bytes:    20904     usecs:   10200.86
+prelude/compile    bytes:     5512     usecs:    1116.60
+prelude/prelude    bytes:     4592     usecs:     215.22
+prelude/exception  bytes:     6896     usecs:    3699.80
+prelude/fixnum     bytes:     2000     usecs:     147.58
+prelude/format     bytes:     6184     usecs:    5058.70
+prelude/lambda     bytes:    97784     usecs:   48295.48
+prelude/list       bytes:    20864     usecs:    6566.62
+prelude/macro      bytes:    58640     usecs:   32036.78
+prelude/reader     bytes:    15216     usecs:   84524.84
+prelude/stream     bytes:      960     usecs:      62.20
+prelude/string     bytes:     2160     usecs:     442.00
+prelude/type       bytes:     8768     usecs:    4547.88
+prelude/vector     bytes:     9472     usecs:    4810.56
 

--- a/src/libenv/core/lib.rs
+++ b/src/libenv/core/lib.rs
@@ -9,7 +9,7 @@ use {
             direct::{DirectInfo, DirectTag, DirectType},
             env::Env,
             functions::{LibFn, LIB_SYMBOLS},
-            future::FuturePool,
+            future::{Future, FuturePool},
             namespace::{Namespace, NsRwLockMap},
             types::Tag,
         },
@@ -23,18 +23,13 @@ use {
             vector::{Core as _, Vector},
         },
     },
-    std::{
-        collections::HashMap,
-        sync::{Arc, Mutex},
-    },
+    std::collections::HashMap,
 };
 use {futures::executor::block_on, futures_locks::RwLock};
 
 lazy_static! {
     pub static ref LIB: Lib = Lib::new().features().stdio();
 }
-
-pub type FutureState = (std::thread::JoinHandle<Tag>, Arc<Mutex<i32>>);
 
 pub struct Lib {
     pub version: &'static str,
@@ -43,7 +38,7 @@ pub struct Lib {
     pub features: RwLock<Vec<Feature>>,
     pub functions: RwLock<HashMap<u64, LibFn>>,
     pub future_id: RwLock<u64>,
-    pub futures: RwLock<HashMap<u64, FutureState>>,
+    pub futures: RwLock<HashMap<u64, Future>>,
     pub env_map: RwLock<HashMap<u64, Env>>,
     pub stdio: RwLock<(Tag, Tag, Tag)>,
     pub streams: RwLock<Vec<RwLock<Stream>>>,


### PR DESCRIPTION
simplify future stack and future struct

docs: no change
tests: no change
regressions no change
srcs: core/{lib.rs, future.rs) change future stack representation
