### PR TITLE
#195 - metrics: use whichever time is in the path

### DIFF
--- a/metrics/footprint/scripts/stats.py
+++ b/metrics/footprint/scripts/stats.py
@@ -9,7 +9,7 @@ import subprocess
 ntests = sys.argv[1]
 
 mu_cmd = '../../dist/mu-sys'
-time_cmd = '/usr/bin/time'
+time_cmd = 'time'
 format = '"%S %U %e %M %w %Z"'
 
 def stats():

--- a/metrics/regression/current.summary
+++ b/metrics/regression/current.summary
@@ -1,40 +1,40 @@
 Perf Metrics Summary: lib
 --------------------
-lib/compile        bytes:     1520     usecs:      49.48
-lib/core           bytes:     5808     usecs:     163.46
-lib/gcd            bytes:      624     usecs:     147.16
-lib/list           bytes:     5296     usecs:     130.14
-lib/namespace      bytes:      240     usecs:       4.26
-lib/number         bytes:     3600     usecs:      87.58
-lib/reader         bytes:     5280     usecs:     117.04
-lib/special-form   bytes:     2400     usecs:      66.72
-lib/stream         bytes:      480     usecs:      13.84
-lib/struct         bytes:      576     usecs:      16.14
-lib/symbol         bytes:     1200     usecs:      34.20
-lib/vector         bytes:     4456     usecs:     109.66
+lib/compile        bytes:     1520     usecs:      42.52
+lib/core           bytes:     5808     usecs:     243.94
+lib/gcd            bytes:      624     usecs:     107.14
+lib/list           bytes:     5296     usecs:     127.74
+lib/namespace      bytes:      240     usecs:       4.28
+lib/number         bytes:     3600     usecs:      92.80
+lib/reader         bytes:     5280     usecs:     111.70
+lib/special-form   bytes:     2400     usecs:      60.64
+lib/stream         bytes:      480     usecs:      13.12
+lib/struct         bytes:      576     usecs:      13.60
+lib/symbol         bytes:     1200     usecs:      27.52
+lib/vector         bytes:     4456     usecs:     101.86
 
 Perf Metrics Summary: frequent
 --------------------
-frequent/core      bytes:     9624     usecs:     655.36
-frequent/fixnum    bytes:     1680     usecs:      41.70
-frequent/float     bytes:     1200     usecs:      30.06
-frequent/list      bytes:     2160     usecs:      53.64
-frequent/vector    bytes:      240     usecs:       6.02
+frequent/core      bytes:     9624     usecs:     521.68
+frequent/fixnum    bytes:     1680     usecs:      37.36
+frequent/float     bytes:     1200     usecs:      27.76
+frequent/list      bytes:     2160     usecs:      51.28
+frequent/vector    bytes:      240     usecs:       5.98
 
 Perf Metrics Summary: prelude
 --------------------
-prelude/closure    bytes:    20904     usecs:   14932.36
-prelude/compile    bytes:     5512     usecs:    1618.60
-prelude/prelude    bytes:     4592     usecs:     330.86
-prelude/exception  bytes:     6896     usecs:    5451.00
-prelude/fixnum     bytes:     2000     usecs:     219.70
-prelude/format     bytes:     6184     usecs:    7399.32
-prelude/lambda     bytes:    97784     usecs:   68731.12
-prelude/list       bytes:    20864     usecs:    9359.18
-prelude/macro      bytes:    58640     usecs:   44168.84
-prelude/reader     bytes:    15216     usecs:  118148.22
-prelude/stream     bytes:      960     usecs:      84.26
-prelude/string     bytes:     2160     usecs:     666.54
-prelude/type       bytes:     8768     usecs:    6402.32
-prelude/vector     bytes:     9472     usecs:    6703.66
+prelude/closure    bytes:    20904     usecs:   10902.82
+prelude/compile    bytes:     5512     usecs:    1229.96
+prelude/prelude    bytes:     4592     usecs:     240.06
+prelude/exception  bytes:     6896     usecs:    3943.14
+prelude/fixnum     bytes:     2000     usecs:     153.48
+prelude/format     bytes:     6184     usecs:    5421.32
+prelude/lambda     bytes:    97784     usecs:   51297.06
+prelude/list       bytes:    20864     usecs:    7026.24
+prelude/macro      bytes:    58640     usecs:   33902.40
+prelude/reader     bytes:    15216     usecs:   89539.42
+prelude/stream     bytes:      960     usecs:      62.28
+prelude/string     bytes:     2160     usecs:     466.56
+prelude/type       bytes:     8768     usecs:    4815.24
+prelude/vector     bytes:     9472     usecs:    5096.88
 


### PR DESCRIPTION
better Linux/macOS interop

docs: no change
tests: no change
regression: no change
srcs: no change