### PR TITLE
#200 - lib: shore up character literal handling

### DIFF
--- a/metrics/regression/current.summary
+++ b/metrics/regression/current.summary
@@ -1,40 +1,40 @@
 Perf Metrics Summary: lib
 --------------------
-lib/compile        bytes:     1520     usecs:      46.14
-lib/core           bytes:     5808     usecs:     153.72
-lib/gcd            bytes:      624     usecs:     138.20
-lib/list           bytes:     5296     usecs:     121.80
-lib/namespace      bytes:      240     usecs:       3.98
-lib/number         bytes:     3600     usecs:      83.12
-lib/reader         bytes:     5280     usecs:     108.92
-lib/special-form   bytes:     2400     usecs:      64.76
-lib/stream         bytes:      480     usecs:      13.02
-lib/struct         bytes:      576     usecs:      14.30
-lib/symbol         bytes:     1200     usecs:      28.68
-lib/vector         bytes:     4456     usecs:     104.20
+lib/compile        bytes:     1520     usecs:      45.40
+lib/core           bytes:     5808     usecs:     152.32
+lib/gcd            bytes:      624     usecs:     143.08
+lib/list           bytes:     5296     usecs:     122.26
+lib/namespace      bytes:      240     usecs:       4.06
+lib/number         bytes:     3600     usecs:      83.16
+lib/reader         bytes:     5280     usecs:     110.56
+lib/special-form   bytes:     2400     usecs:      63.06
+lib/stream         bytes:      480     usecs:      13.26
+lib/struct         bytes:      576     usecs:      13.52
+lib/symbol         bytes:     1200     usecs:      28.78
+lib/vector         bytes:     4456     usecs:     104.06
 
 Perf Metrics Summary: frequent
 --------------------
-frequent/core      bytes:     9624     usecs:     626.42
-frequent/fixnum    bytes:     1680     usecs:      39.16
-frequent/float     bytes:     1200     usecs:      27.14
-frequent/list      bytes:     2160     usecs:      49.00
-frequent/vector    bytes:      240     usecs:       5.72
+frequent/core      bytes:     9624     usecs:     640.34
+frequent/fixnum    bytes:     1680     usecs:      38.78
+frequent/float     bytes:     1200     usecs:      27.28
+frequent/list      bytes:     2160     usecs:      49.28
+frequent/vector    bytes:      240     usecs:       5.54
 
 Perf Metrics Summary: prelude
 --------------------
-prelude/closure    bytes:    20904     usecs:   13392.96
-prelude/compile    bytes:     5512     usecs:    1513.82
-prelude/prelude    bytes:     4592     usecs:     305.68
-prelude/exception  bytes:     6896     usecs:    4912.34
-prelude/fixnum     bytes:     2000     usecs:     213.50
-prelude/format     bytes:     6184     usecs:    7085.26
-prelude/lambda     bytes:    97784     usecs:   66445.28
-prelude/list       bytes:    20864     usecs:    9224.66
-prelude/macro      bytes:    58640     usecs:   42642.56
-prelude/reader     bytes:    15216     usecs:  116692.26
-prelude/stream     bytes:      960     usecs:      75.72
-prelude/string     bytes:     2160     usecs:     615.36
-prelude/type       bytes:     8768     usecs:    6069.10
-prelude/vector     bytes:     9472     usecs:    6350.66
+prelude/closure    bytes:    20904     usecs:   13784.90
+prelude/compile    bytes:     5512     usecs:    1539.54
+prelude/prelude    bytes:     4592     usecs:     302.70
+prelude/exception  bytes:     6896     usecs:    4845.20
+prelude/fixnum     bytes:     2000     usecs:     214.66
+prelude/format     bytes:     6184     usecs:    6710.08
+prelude/lambda     bytes:    97784     usecs:   63728.20
+prelude/list       bytes:    20864     usecs:    8941.34
+prelude/macro      bytes:    58640     usecs:   42188.22
+prelude/reader     bytes:    15216     usecs:  112414.76
+prelude/stream     bytes:      960     usecs:      74.80
+prelude/string     bytes:     2160     usecs:     617.74
+prelude/type       bytes:     8768     usecs:    6074.82
+prelude/vector     bytes:     9472     usecs:    6539.80
 


### PR DESCRIPTION
allow whitespace character literals, better error checking

docs: no change
tests: no change
regression: no change
srcs: libenv/core/reader.rs got a better read_sharp_char function