### PR TITLE
#228 - lib: clean up direct conses

### DIFF
--- a/metrics/regression/current.summary
+++ b/metrics/regression/current.summary
@@ -1,40 +1,40 @@
 Perf Metrics Summary: lib
 --------------------
-lib/compile        bytes:     1520     usecs:     112.42
-lib/core           bytes:     5808     usecs:     422.96
-lib/gcd            bytes:      624     usecs:     329.48
-lib/list           bytes:     5296     usecs:     289.66
-lib/namespace      bytes:      240     usecs:       9.36
-lib/number         bytes:     3600     usecs:     226.86
-lib/reader         bytes:     5280     usecs:     375.00
-lib/special-form   bytes:     2400     usecs:     176.20
-lib/stream         bytes:      480     usecs:      45.40
-lib/struct         bytes:      576     usecs:      45.22
-lib/symbol         bytes:     1200     usecs:     102.20
-lib/vector         bytes:     4456     usecs:     354.42
+lib/compile        bytes:     1520     usecs:     154.65
+lib/core           bytes:     5808     usecs:     396.05
+lib/gcd            bytes:      624     usecs:     443.70
+lib/list           bytes:     5296     usecs:     395.10
+lib/namespace      bytes:      240     usecs:       5.05
+lib/number         bytes:     3600     usecs:     230.75
+lib/reader         bytes:     5280     usecs:     314.80
+lib/special-form   bytes:     2400     usecs:     162.30
+lib/stream         bytes:      480     usecs:      36.40
+lib/struct         bytes:      576     usecs:      41.80
+lib/symbol         bytes:     1200     usecs:      75.70
+lib/vector         bytes:     4456     usecs:     341.30
 
 Perf Metrics Summary: frequent
 --------------------
-frequent/core      bytes:     9624     usecs:    1899.62
-frequent/fixnum    bytes:     1680     usecs:     122.92
-frequent/float     bytes:     1200     usecs:      92.70
-frequent/list      bytes:     2160     usecs:     163.64
-frequent/vector    bytes:      240     usecs:      19.32
+frequent/core      bytes:     9624     usecs:    2104.30
+frequent/fixnum    bytes:     1680     usecs:     111.80
+frequent/float     bytes:     1200     usecs:      98.95
+frequent/list      bytes:     2160     usecs:     185.60
+frequent/vector    bytes:      240     usecs:      20.80
 
 Perf Metrics Summary: prelude
 --------------------
-prelude/closure    bytes:    20904     usecs:   15426.70
-prelude/compile    bytes:     5512     usecs:    1711.70
-prelude/prelude    bytes:     4592     usecs:     449.18
-prelude/exception  bytes:     6920     usecs:    5594.66
-prelude/fixnum     bytes:     2000     usecs:     251.28
-prelude/format     bytes:     6152     usecs:    7712.36
-prelude/lambda     bytes:    97784     usecs:   74308.26
-prelude/list       bytes:    20864     usecs:    9968.80
-prelude/macro      bytes:    58416     usecs:   47797.60
-prelude/reader     bytes:    15032     usecs:  126849.12
-prelude/stream     bytes:      960     usecs:      93.72
-prelude/string     bytes:     2160     usecs:     691.44
-prelude/type       bytes:     8768     usecs:    6982.26
-prelude/vector     bytes:     9472     usecs:    7363.38
+prelude/closure    bytes:    20904     usecs:   15357.15
+prelude/compile    bytes:     5512     usecs:    1707.95
+prelude/prelude    bytes:     4592     usecs:     448.00
+prelude/exception  bytes:     6920     usecs:    5499.40
+prelude/fixnum     bytes:     2000     usecs:     248.75
+prelude/format     bytes:     6152     usecs:    7541.15
+prelude/lambda     bytes:    97784     usecs:   72215.35
+prelude/list       bytes:    20864     usecs:    9981.45
+prelude/macro      bytes:    58416     usecs:   47749.05
+prelude/reader     bytes:    15032     usecs:  126325.15
+prelude/stream     bytes:      960     usecs:      92.65
+prelude/string     bytes:     2160     usecs:     673.10
+prelude/type       bytes:     8768     usecs:    7061.95
+prelude/vector     bytes:     9472     usecs:    7429.15
 

--- a/src/librt/types/cons.rs
+++ b/src/librt/types/cons.rs
@@ -5,7 +5,7 @@
 use crate::{
     core::{
         apply::Core as _,
-        direct::{DirectInfo, DirectTag, DirectType},
+        direct::{DirectInfo, DirectTag, DirectType, ExtType},
         env::Env,
         exception::{self, Condition, Exception},
         frame::Frame,
@@ -150,8 +150,8 @@ impl Core for Cons {
     fn heap_size(_: &Env, cons: Tag) -> usize {
         match cons {
             Tag::Direct(dtag) => match dtag.dtype() {
-                DirectType::Ext => match dtag.info() {
-                    DirectTag::EXT_TYPE_CONS => std::mem::size_of::<DirectTag>(),
+                DirectType::Ext => match dtag.info().try_into() {
+                    Ok(ExtType::Cons) => std::mem::size_of::<DirectTag>(),
                     _ => panic!(),
                 },
                 _ => panic!(),

--- a/src/librt/types/core_stream.rs
+++ b/src/librt/types/core_stream.rs
@@ -66,8 +66,8 @@ impl Core for Stream {
     fn to_stream_index(env: &Env, tag: Tag) -> exception::Result<usize> {
         match tag {
             Tag::Direct(dtag) => match dtag.dtype() {
-                DirectType::Ext => match dtag.info() {
-                    DirectTag::EXT_TYPE_STREAM => Ok(dtag.data() as usize),
+                DirectType::Ext => match dtag.info().try_into() {
+                    Ok(ExtType::Stream) => Ok(dtag.data() as usize),
                     _ => panic!(),
                 },
                 _ => panic!(),


### PR DESCRIPTION
code hygeine for directs conses

docs: no change
tests: no change
regression: no change
srcs: match directly on DirectType ExtType, remove intermediate consts 