### PR TITLE
#223 - prelude: #: broken

### DIFF
--- a/metrics/regression/current.summary
+++ b/metrics/regression/current.summary
@@ -1,40 +1,40 @@
 Perf Metrics Summary: lib
 --------------------
-lib/compile        bytes:     1520     usecs:     131.85
-lib/core           bytes:     5808     usecs:     474.65
-lib/gcd            bytes:      624     usecs:     336.50
-lib/list           bytes:     5296     usecs:     409.55
-lib/namespace      bytes:      240     usecs:      13.75
-lib/number         bytes:     3600     usecs:     282.30
-lib/reader         bytes:     5280     usecs:     355.15
-lib/special-form   bytes:     2400     usecs:     109.20
-lib/stream         bytes:      480     usecs:      18.55
-lib/struct         bytes:      576     usecs:      15.85
-lib/symbol         bytes:     1200     usecs:      55.05
-lib/vector         bytes:     4456     usecs:     247.70
+lib/compile        bytes:     1520     usecs:      53.05
+lib/core           bytes:     5808     usecs:     199.15
+lib/gcd            bytes:      624     usecs:     132.40
+lib/list           bytes:     5296     usecs:     169.10
+lib/namespace      bytes:      240     usecs:       7.00
+lib/number         bytes:     3600     usecs:     112.30
+lib/reader         bytes:     5280     usecs:     155.30
+lib/special-form   bytes:     2400     usecs:      82.15
+lib/stream         bytes:      480     usecs:      17.20
+lib/struct         bytes:      576     usecs:      17.45
+lib/symbol         bytes:     1200     usecs:      38.10
+lib/vector         bytes:     4456     usecs:     139.70
 
 Perf Metrics Summary: frequent
 --------------------
-frequent/core      bytes:     9624     usecs:    1280.65
-frequent/fixnum    bytes:     1680     usecs:     117.95
-frequent/float     bytes:     1200     usecs:      51.85
-frequent/list      bytes:     2160     usecs:      82.50
-frequent/vector    bytes:      240     usecs:      21.15
+frequent/core      bytes:     9624     usecs:     660.65
+frequent/fixnum    bytes:     1680     usecs:      52.15
+frequent/float     bytes:     1200     usecs:      38.50
+frequent/list      bytes:     2160     usecs:      67.95
+frequent/vector    bytes:      240     usecs:       8.25
 
 Perf Metrics Summary: prelude
 --------------------
-prelude/closure    bytes:    20904     usecs:   16176.90
-prelude/compile    bytes:     5512     usecs:    1779.85
-prelude/prelude    bytes:     4592     usecs:     421.65
-prelude/exception  bytes:     6920     usecs:    5755.60
-prelude/fixnum     bytes:     2000     usecs:     256.25
-prelude/format     bytes:     6144     usecs:    7699.80
-prelude/lambda     bytes:    97784     usecs:   73014.10
-prelude/list       bytes:    20864     usecs:   10037.30
-prelude/macro      bytes:    58416     usecs:   47269.65
-prelude/reader     bytes:    15032     usecs:  124639.25
-prelude/stream     bytes:      960     usecs:      93.70
-prelude/string     bytes:     2160     usecs:     703.60
-prelude/type       bytes:     8768     usecs:    6998.15
-prelude/vector     bytes:     9472     usecs:    7201.15
+prelude/closure    bytes:    20904     usecs:   12637.80
+prelude/compile    bytes:     5512     usecs:    1459.50
+prelude/prelude    bytes:     4592     usecs:     310.65
+prelude/exception  bytes:     6920     usecs:    4595.45
+prelude/fixnum     bytes:     2000     usecs:     185.30
+prelude/format     bytes:     6144     usecs:    6241.70
+prelude/lambda     bytes:    97784     usecs:   59613.50
+prelude/list       bytes:    20864     usecs:    8305.40
+prelude/macro      bytes:    58416     usecs:   39385.10
+prelude/reader     bytes:    15032     usecs:  103753.70
+prelude/stream     bytes:      960     usecs:      78.30
+prelude/string     bytes:     2160     usecs:     545.25
+prelude/type       bytes:     8768     usecs:    5776.85
+prelude/vector     bytes:     9472     usecs:    6072.55
 

--- a/src/prelude/read-macro.l
+++ b/src/prelude/read-macro.l
@@ -98,13 +98,17 @@
    (:lambda (ch stream)
       (lib:eval (prelude:compile (prelude:read stream () ())))))
 
-(lib:intern prelude "%read-sharp-symbol"
+(lib:intern prelude "%read-sharp-colon"
    (:lambda (ch stream)
-     ((:lambda (symbol)
-          (:if (lib:eq :symbol (lib:type-of symbol))
-               (lib:make-symbol (lib:symbol-name symbol))
-               (prelude:raise symbol 'prelude:%read-sharp-symbol "not a symbol")))
-       (prelude:%read-atom ch stream))))
+     ((:lambda (ch)
+        (:if ch
+             ((:lambda (symbol)
+                (:if (lib:eq :symbol (lib:type-of symbol))
+                     (lib:make-symbol (lib:symbol-name symbol))
+                     (prelude:raise symbol 'prelude:%read-sharp-colon "not a symbol")))
+              (prelude:%read-atom ch stream))              
+             (prelude:raise () 'prelude:%read-sharp-colon "early eof")))
+     (prelude:read-char stream () ()))))
 
 (lib:intern prelude "%read-sharp-number"
   (:lambda (base stream)
@@ -150,7 +154,7 @@
        (#\b . prelude:%read-sharp-number)
        (#\x . prelude:%read-sharp-number)
        (#\d . prelude:%read-sharp-number)
-       (#\: . prelude:%read-sharp-symbol)))))
+       (#\: . prelude:%read-sharp-colon)))))
 
 ;;;
 ;;; list reader

--- a/tests/prelude/reader
+++ b/tests/prelude/reader
@@ -11,6 +11,7 @@
 (prelude:read (prelude:make-string-stream :input "a #||#") () ())	a
 (prelude:read (prelude:make-string-stream :input "#||# a;a") () ())	a
 (prelude:read (prelude:make-string-stream :input "#||# a ;a") () ())	a
+(prelude:read (prelude:make-string-stream :input "#:abc") () ())	abc
 (prelude:read (prelude:make-string-stream :input "prelude:a") () ())	prelude:a
 (prelude:read (prelude:make-string-stream :input "abcdefgh") () ())	abcdefgh
 (prelude:read (prelude:make-string-stream :input "prelude:abcdefgh") () ())	prelude:abcdefgh

--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -29,12 +29,12 @@ prelude    format         total: 15       pass: 15       fail: 0        exceptio
 prelude    lambda         total: 23       pass: 23       fail: 0        exceptions: 0       
 prelude    list           total: 76       pass: 76       fail: 0        exceptions: 0       
 prelude    macro          total: 13       pass: 13       fail: 0        exceptions: 0       
-prelude    reader         total: 68       pass: 68       fail: 0        exceptions: 0       
+prelude    reader         total: 69       pass: 69       fail: 0        exceptions: 0       
 prelude    stream         total: 20       pass: 20       fail: 0        exceptions: 0       
 prelude    string         total: 20       pass: 20       fail: 0        exceptions: 0       
 prelude    symbol         total: 3        pass: 3        fail: 0        exceptions: 0       
 prelude    types          total: 43       pass: 43       fail: 0        exceptions: 0       
 prelude    vector         total: 25       pass: 25       fail: 0        exceptions: 0       
 -----------------------
-prelude                   total: 407      pass: 395      fail: 10       exceptions: 2         
+prelude                   total: 408      pass: 396      fail: 10       exceptions: 2         
 


### PR DESCRIPTION
now works in prelude, always worked in lib

docs: no change
tests: add prelude #: test
regression: no change
srcs: prelude/read-macro.l got a better %read-sharp-colon
