### PR TITLE
#246 - prelude: rationalize quasiquote function names

### DIFF
--- a/metrics/regression/current.summary
+++ b/metrics/regression/current.summary
@@ -1,40 +1,40 @@
 Perf Metrics Summary: lib
 --------------------
-lib/compile        bytes:     1520     usecs:      50.56
-lib/core           bytes:     5808     usecs:     176.48
-lib/gcd            bytes:      624     usecs:     167.10
-lib/list           bytes:     5296     usecs:     137.88
-lib/namespace      bytes:      240     usecs:       4.78
-lib/number         bytes:     3600     usecs:      93.18
-lib/reader         bytes:     5280     usecs:     124.70
-lib/special-form   bytes:     2400     usecs:      73.40
-lib/stream         bytes:      480     usecs:      15.58
-lib/struct         bytes:      576     usecs:      16.02
-lib/symbol         bytes:     1200     usecs:      32.68
-lib/vector         bytes:     4456     usecs:     118.32
+lib/compile        bytes:     1520     usecs:      52.00
+lib/core           bytes:     5808     usecs:     193.35
+lib/gcd            bytes:      624     usecs:     140.20
+lib/list           bytes:     5296     usecs:     157.75
+lib/namespace      bytes:      240     usecs:       5.60
+lib/number         bytes:     3600     usecs:     106.50
+lib/reader         bytes:     5280     usecs:     144.05
+lib/special-form   bytes:     2400     usecs:      79.75
+lib/stream         bytes:      480     usecs:      16.30
+lib/struct         bytes:      576     usecs:      16.70
+lib/symbol         bytes:     1200     usecs:      37.20
+lib/vector         bytes:     4456     usecs:     130.75
 
 Perf Metrics Summary: frequent
 --------------------
-frequent/core      bytes:     9624     usecs:     757.12
-frequent/fixnum    bytes:     1680     usecs:      43.04
-frequent/float     bytes:     1200     usecs:      31.48
-frequent/list      bytes:     2160     usecs:      56.06
-frequent/vector    bytes:      240     usecs:       6.42
+frequent/core      bytes:     9624     usecs:     703.40
+frequent/fixnum    bytes:     1680     usecs:      48.50
+frequent/float     bytes:     1200     usecs:      35.90
+frequent/list      bytes:     2160     usecs:      64.30
+frequent/vector    bytes:      240     usecs:       8.05
 
 Perf Metrics Summary: prelude
 --------------------
-prelude/closure    bytes:    20904     usecs:   19822.46
-prelude/compile    bytes:    38856     usecs:   37922.22
-prelude/prelude    bytes:     4592     usecs:     325.54
-prelude/exception  bytes:     6920     usecs:    7125.40
-prelude/fixnum     bytes:     2000     usecs:     208.64
-prelude/format     bytes:     6144     usecs:    8775.58
-prelude/lambda     bytes:    97784     usecs:   94412.46
-prelude/list       bytes:    20864     usecs:   12601.58
-prelude/macro      bytes:    58416     usecs:   61475.28
-prelude/reader     bytes:    15032     usecs:  152106.34
-prelude/stream     bytes:      960     usecs:      83.00
-prelude/string     bytes:     2160     usecs:     715.94
-prelude/type       bytes:     8768     usecs:    8228.12
-prelude/vector     bytes:     9472     usecs:    9299.66
+prelude/closure    bytes:    20904     usecs:   15802.85
+prelude/compile    bytes:    38856     usecs:   30152.10
+prelude/prelude    bytes:     4592     usecs:     292.90
+prelude/exception  bytes:     6920     usecs:    5731.20
+prelude/fixnum     bytes:     2000     usecs:     180.05
+prelude/format     bytes:     6144     usecs:    7060.25
+prelude/lambda     bytes:    97784     usecs:   75767.45
+prelude/list       bytes:    20864     usecs:   10597.55
+prelude/macro      bytes:    58416     usecs:   49531.65
+prelude/reader     bytes:    15032     usecs:  122860.85
+prelude/stream     bytes:      960     usecs:      74.25
+prelude/string     bytes:     2160     usecs:     611.25
+prelude/type       bytes:     8768     usecs:    6818.45
+prelude/vector     bytes:     9472     usecs:    7650.65
 

--- a/src/prelude/compile.l
+++ b/src/prelude/compile.l
@@ -84,15 +84,15 @@
 ;;;
 (lib:intern prelude "%compile-quasi"
    (:lambda (form env)
-     (prelude:compile (prelude:%qq-compile (lib:nth 1 form)))))               
+     (prelude:compile (prelude:%quasi-compile (lib:nth 1 form)))))               
    
 ;;;
 ;;; prelude compiler
 ;;;
 ;;; rewrites a function call/special call/macro call against an environment
-;;; into something the runtime can execute. constants compile to themselves.
+;;; into something the runtime can execute.
 ;;;
-;;; returns a mu form or %fn type (in the case of a define-prelude-lambda)
+;;; returns a lib form or %fn type (in the case of a define-prelude-lambda)
 ;;;
 (lib:intern prelude "%compile"
    (:lambda (form env)
@@ -121,8 +121,7 @@
            form)))
 
 ;;;
-;;; the external compile interface, compiles in
-;;; the null environment
+;;; repl's compile interface, compiles in the null environment
 ;;;
 (lib:intern prelude "compile"
    (:lambda (form)

--- a/src/prelude/quasiquote.l
+++ b/src/prelude/quasiquote.l
@@ -10,11 +10,11 @@
    (:lambda (form)
      `(,form)))
 
-(lib:intern prelude "%qq-func-map"
+(lib:intern prelude "%quasi-func-map"
    (:lambda (key map)
      (lib:cdr (prelude:assoc key map))))
 
-(lib:intern prelude "%qq-read"
+(lib:intern prelude "%quasi-read"
    (:lambda (stream)
      ((:lambda (ch syntax-map)
         (:if (prelude:null ch)
@@ -25,7 +25,7 @@
                      (lib:apply (lib:cdr type-map) ())))
                 (prelude:assoc ch syntax-map))))
         (prelude:%read-consume-ws stream)
-        `(,(lib:cons #\( (:lambda () `(:list ,(prelude:%qq-read-list stream))))
+        `(,(lib:cons #\( (:lambda () `(:list ,(prelude:%quasi-read-list stream))))
            ,(lib:cons #\) (:lambda () `(:list-)))
            ,(lib:cons #\, (:lambda ()
                            ((:lambda (ch)
@@ -37,10 +37,10 @@
                                           (prelude:unread-char ch stream)
                                           `(:form ,(prelude:read stream () ())))))))
                             (prelude:read-char stream () ()))))
-           ,(lib:cons #\' (:lambda () `(:qquote ,(prelude:%qq-read stream))))
+           ,(lib:cons #\' (:lambda () `(:qquote ,(prelude:%quasi-read stream))))
            ,(lib:cons #\` (:lambda () `(:quasi ,(prelude:read stream () ()))))))))
 
-(lib:intern prelude "%qq-read-list"
+(lib:intern prelude "%quasi-read-list"
    (:lambda (stream)
      ((:lambda (syntax-map)
          (lib:cdr
@@ -55,10 +55,10 @@
                                 (prelude:error stream "qquote: early end of file~%" ())
                                 ((:lambda (type-fn)
                                    (lib:apply type-fn `(,expr ,list)))
-                                 (prelude:%qq-func-map type syntax-map))))
+                                 (prelude:%quasi-func-map type syntax-map))))
                          (lib:car syntax)
                          (lib:cdr syntax)))
-                      (prelude:%qq-read stream))))
+                      (prelude:%quasi-read stream))))
               (lib:car loop)
               (lib:cdr loop)))
            ())))
@@ -79,18 +79,18 @@
          ,(lib:cons :list-  (:lambda (expr list)
                              (lib:cons :t list)))
          ,(lib:cons :quasi  (:lambda (expr list)
-                             (lib:cons () (lib:append list `(,(prelude:%qq-read stream))))))))))
+                             (lib:cons () (lib:append list `(,(prelude:%quasi-read stream))))))))))
 
-(lib:intern prelude "%qq-compile"
-   (:lambda (qq-expr)
+(lib:intern prelude "%quasi-compile"
+   (:lambda (quasi-expr)
      ((:lambda (type expr compiler-map)
         ((:lambda (type-fn)
            (:if (prelude:null type-fn)
                 (prelude:error type "backquote: unmapped type ~A~%" `(,type))
                 (lib:apply type-fn `(,expr))))
-         (prelude:%qq-func-map type compiler-map)))
-      (lib:nth 0 qq-expr)
-      (lib:nth 1 qq-expr)
+         (prelude:%quasi-func-map type compiler-map)))
+      (lib:nth 0 quasi-expr)
+      (lib:nth 1 quasi-expr)
       `(,(lib:cons :l-comma  (:lambda (expr) `(lib:cons ,expr ())))
          ,(lib:cons :l-list  (:lambda (expr)
                               ((:lambda (loop)
@@ -99,7 +99,7 @@
                                  (:if (prelude:null list)
                                       list
                                       `(lib:append
-                                        ,(prelude:%qq-compile (lib:car list))
+                                        ,(prelude:%quasi-compile (lib:car list))
                                         ,(lib:apply loop `(,loop ,(lib:cdr list)))))))))
          ,(lib:cons :l-form  (:lambda (expr)
                               ((:lambda (quote)
@@ -113,7 +113,7 @@
                                  (:if (prelude:null list)
                                       list
                                       `(lib:append
-                                        ,(prelude:%qq-compile (lib:car list))
+                                        ,(prelude:%quasi-compile (lib:car list))
                                         ,(lib:apply loop `(,loop ,(lib:cdr list)))))))))
          ,(lib:cons :form    (:lambda (expr)
                               `(:quote ,expr)))
@@ -122,12 +122,12 @@
                                  (:if (lib:eq :form type)
                                       (lib:cdr expr)
                                       (:if (lib:eq :quote type)
-                                           (prelude:%qq-compile expr)
+                                           (prelude:%quasi-compile expr)
                                            ())))
                                (lib:car expr))))
          ,(lib:cons :qquote   (:lambda (expr)
-                               `(:quote ,(prelude:%qq-compile expr))))))))
+                               `(:quote ,(prelude:%quasi-compile expr))))))))
 
-(lib:intern prelude "%qq-reader"
+(lib:intern prelude "%read-quasi"
    (:lambda (char stream)
-     `(%quasi% ,(prelude:%qq-read stream))))
+     `(%quasi% ,(prelude:%quasi-read stream))))

--- a/src/prelude/read-macro.l
+++ b/src/prelude/read-macro.l
@@ -239,7 +239,7 @@
        '((#\" . prelude:%read-string)
          (#\# . prelude:%read-sharp)
          (#\' . prelude:%read-quote)
-         (#\` . prelude:%qq-reader)
+         (#\` . prelude:%read-quasi)
          (#\( . prelude:%read-list)
          (#\) . prelude:%read-list-eol)
          (#\; . prelude:%read-line-comment)))))


### PR DESCRIPTION
superficial renaming, no semantics changes

docs: no change
tests: no change
regression: no change
srcs: rename all the qq- functions
