### PR TITLE
#250 - libcore: audit explicit returns after block_on

### DIFF
--- a/metrics/regression/current.summary
+++ b/metrics/regression/current.summary
@@ -1,40 +1,40 @@
 Perf Metrics Summary: core
 --------------------
-core/compile       bytes:     1520     usecs:      50.40
-core/core          bytes:     5808     usecs:     172.50
-core/gcd           bytes:      624     usecs:     165.15
-core/list          bytes:     5296     usecs:     136.80
-core/namespace     bytes:      240     usecs:       4.50
-core/number        bytes:     3600     usecs:      91.65
-core/reader        bytes:     5280     usecs:     120.25
-core/special-form  bytes:     2400     usecs:      70.65
-core/stream        bytes:      480     usecs:      14.25
-core/struct        bytes:      576     usecs:      15.20
-core/symbol        bytes:     1200     usecs:      32.30
-core/vector        bytes:     4456     usecs:     116.35
+core/compile       bytes:     1520     usecs:      49.90
+core/core          bytes:     5808     usecs:     173.95
+core/gcd           bytes:      624     usecs:     165.75
+core/list          bytes:     5296     usecs:     136.25
+core/namespace     bytes:      240     usecs:       4.60
+core/number        bytes:     3600     usecs:      91.45
+core/reader        bytes:     5280     usecs:     122.25
+core/special-form  bytes:     2400     usecs:      73.05
+core/stream        bytes:      480     usecs:      15.25
+core/struct        bytes:      576     usecs:      15.40
+core/symbol        bytes:     1200     usecs:      32.05
+core/vector        bytes:     4456     usecs:     116.55
 
 Perf Metrics Summary: frequent
 --------------------
-frequent/core      bytes:     9624     usecs:     750.90
-frequent/fixnum    bytes:     1680     usecs:      42.70
-frequent/float     bytes:     1200     usecs:      31.00
-frequent/list      bytes:     2160     usecs:      56.70
-frequent/vector    bytes:      240     usecs:       6.15
+frequent/core      bytes:     9624     usecs:     765.25
+frequent/fixnum    bytes:     1680     usecs:      42.25
+frequent/float     bytes:     1200     usecs:      30.85
+frequent/list      bytes:     2160     usecs:      54.35
+frequent/vector    bytes:      240     usecs:       6.20
 
 Perf Metrics Summary: prelude
 --------------------
-prelude/closure    bytes:    20904     usecs:   19650.10
-prelude/compile    bytes:    38856     usecs:   36118.15
-prelude/prelude    bytes:     4592     usecs:     349.50
-prelude/exception  bytes:     6920     usecs:    6708.00
-prelude/fixnum     bytes:     2000     usecs:     224.05
-prelude/format     bytes:     6144     usecs:    8261.10
-prelude/lambda     bytes:    97784     usecs:   90888.90
-prelude/list       bytes:    20864     usecs:   12346.10
-prelude/macro      bytes:    58416     usecs:   60127.20
-prelude/reader     bytes:    15032     usecs:  147054.25
-prelude/stream     bytes:      960     usecs:      79.30
-prelude/string     bytes:     2160     usecs:     738.60
-prelude/type       bytes:     8768     usecs:    8173.35
-prelude/vector     bytes:     9472     usecs:    9269.65
+prelude/closure    bytes:    20904     usecs:   19438.15
+prelude/compile    bytes:    38856     usecs:   37177.05
+prelude/prelude    bytes:     4592     usecs:     341.00
+prelude/exception  bytes:     6920     usecs:    7024.15
+prelude/fixnum     bytes:     2000     usecs:     225.05
+prelude/format     bytes:     6144     usecs:    8386.50
+prelude/lambda     bytes:    97784     usecs:   89573.20
+prelude/list       bytes:    20864     usecs:   12296.45
+prelude/macro      bytes:    58416     usecs:   61199.40
+prelude/reader     bytes:    15032     usecs:  148614.50
+prelude/stream     bytes:      960     usecs:      78.80
+prelude/string     bytes:     2160     usecs:     735.30
+prelude/type       bytes:     8768     usecs:    8112.30
+prelude/vector     bytes:     9472     usecs:    9114.35
 

--- a/src/libcore/core/exception.rs
+++ b/src/libcore/core/exception.rs
@@ -152,6 +152,7 @@ impl Core for Exception {
 
         if *signal_ref {
             *signal_ref = false;
+
             Err(Exception::new(
                 env,
                 Condition::SigInt,

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -258,17 +258,30 @@ impl Env {
                 match self.read(istream, false, eof_value) {
                     Ok(form) => {
                         if self.eq(form, eof_value) {
+                            drop(env_ref);
                             return Ok(true);
                         }
                         match self.compile(form) {
                             Ok(form) => match self.eval(form) {
                                 Ok(_) => (),
-                                Err(e) => return Err(e),
+                                Err(e) => {
+                                    drop(env_ref);
+
+                                    return Err(e);
+                                }
                             },
-                            Err(e) => return Err(e),
+                            Err(e) => {
+                                drop(env_ref);
+
+                                return Err(e);
+                            }
                         }
                     }
-                    Err(e) => return Err(e),
+                    Err(e) => {
+                        drop(env_ref);
+
+                        return Err(e);
+                    }
                 }
             }
         } else {

--- a/src/libcore/streams/operator.rs
+++ b/src/libcore/streams/operator.rs
@@ -72,12 +72,12 @@ impl SystemStream {
     pub fn close(&self) -> Option<()> {
         match self {
             Self::StdInput | Self::StdOutput | Self::StdError => (),
-            Self::Reader(file) => std::mem::drop(block_on(file.read())),
+            Self::Reader(file) => drop(block_on(file.read())),
             Self::Writer(file) => {
                 let mut file = block_on(file.write());
                 let _unused = task::block_on(async { file.flush().await });
 
-                std::mem::drop(file)
+                drop(file)
             }
             SystemStream::String(_) => (),
         };

--- a/src/libcore/types/core_stream.rs
+++ b/src/libcore/types/core_stream.rs
@@ -195,6 +195,8 @@ impl Core for Stream {
                 let mut stream = block_on(stream_ref.write());
 
                 if stream.direction.eq_(&Symbol::keyword("output")) {
+                    drop(streams_ref);
+                    drop(stream);
                     return Err(Exception::new(
                         env,
                         Condition::Stream,
@@ -234,6 +236,9 @@ impl Core for Stream {
                 let mut stream = block_on(stream_ref.write());
 
                 if stream.direction.eq_(&Symbol::keyword("output")) {
+                    drop(streams_ref);
+                    drop(stream);
+
                     return Err(Exception::new(
                         env,
                         Condition::Stream,
@@ -281,6 +286,9 @@ impl Core for Stream {
                 SystemStream::close(&stream.system);
 
                 if stream.direction.eq_(&Symbol::keyword("output")) {
+                    drop(streams_ref);
+                    drop(stream);
+
                     return Err(Exception::new(
                         env,
                         Condition::Type,
@@ -318,6 +326,9 @@ impl Core for Stream {
                 let stream = block_on(stream_ref.read());
 
                 if stream.direction.eq_(&Symbol::keyword("input")) {
+                    drop(streams_ref);
+                    drop(stream);
+
                     return Err(Exception::new(env, Condition::Type, "core:write-char", tag));
                 }
 
@@ -339,6 +350,9 @@ impl Core for Stream {
                 let stream = block_on(stream_ref.read());
 
                 if stream.direction.eq_(&Symbol::keyword("input")) {
+                    drop(streams_ref);
+                    drop(stream);
+
                     return Err(Exception::new(env, Condition::Type, "core:write-byte", tag));
                 }
 

--- a/src/libcore/types/namespace.rs
+++ b/src/libcore/types/namespace.rs
@@ -69,6 +69,8 @@ impl Namespace {
         let len = ns_ref.len();
 
         if ns_ref.iter().any(|(_, ns_name, _)| name == ns_name) {
+            drop(ns_ref);
+
             return Err(Exception::new(
                 env,
                 Condition::Type,
@@ -469,7 +471,11 @@ impl CoreFunction for Namespace {
                         Some(sym) => sym,
                         None => Tag::nil(),
                     },
-                    None => return Err(Exception::new(env, Condition::Type, "core:find", ns_tag)),
+                    None => {
+                        drop(ns_ref);
+
+                        return Err(Exception::new(env, Condition::Type, "core:find", ns_tag));
+                    }
                 }
             }
             _ => return Err(Exception::new(env, Condition::Type, "core:find", ns_tag)),


### PR DESCRIPTION
found a couple, should avoid error deadlocks

docs: no change
tests: no change
regression: no change
srcs: look at every block_on, add some explicit drops before returns