### PR TITLE
#260 - libcore: use ? operator where relevant

### DIFF
--- a/metrics/footprint/scripts/stats.py
+++ b/metrics/footprint/scripts/stats.py
@@ -22,7 +22,6 @@ def stats():
         '-l', '../../src/prelude/prelude.l',
         '-l', '../../src/prelude/break.l',
         '-l', '../../src/prelude/compile.l',
-        '-l', '../../src/prelude/ctype.l',
         '-l', '../../src/prelude/describe.l',
         '-l', '../../src/prelude/environment.l',
         '-l', '../../src/prelude/exception.l',

--- a/metrics/regression/current.summary
+++ b/metrics/regression/current.summary
@@ -1,40 +1,40 @@
 Perf Metrics Summary: core
 --------------------
-core/compile       bytes:     1520     usecs:      51.20
-core/core          bytes:     5808     usecs:     196.75
-core/gcd           bytes:      624     usecs:     135.75
-core/list          bytes:     5296     usecs:     162.10
-core/namespace     bytes:      240     usecs:       6.00
-core/number        bytes:     3600     usecs:     107.95
-core/reader        bytes:     5280     usecs:     145.90
-core/special-form  bytes:     2400     usecs:      82.85
-core/stream        bytes:      480     usecs:      17.70
-core/struct        bytes:      576     usecs:      18.40
-core/symbol        bytes:     1200     usecs:      39.75
-core/vector        bytes:     4456     usecs:     144.85
+core/compile       bytes:     1520     usecs:      49.96
+core/core          bytes:     5808     usecs:     179.82
+core/gcd           bytes:      624     usecs:     168.18
+core/list          bytes:     5296     usecs:     138.74
+core/namespace     bytes:      240     usecs:       4.90
+core/number        bytes:     3600     usecs:      92.22
+core/reader        bytes:     5280     usecs:     120.96
+core/special-form  bytes:     2400     usecs:      71.92
+core/stream        bytes:      480     usecs:      15.10
+core/struct        bytes:      576     usecs:      15.22
+core/symbol        bytes:     1200     usecs:      32.04
+core/vector        bytes:     4456     usecs:     118.40
 
 Perf Metrics Summary: frequent
 --------------------
-frequent/core      bytes:     9624     usecs:     700.75
-frequent/fixnum    bytes:     1680     usecs:      49.45
-frequent/float     bytes:     1200     usecs:      37.00
-frequent/list      bytes:     2160     usecs:      65.05
-frequent/vector    bytes:      240     usecs:       8.25
+frequent/core      bytes:     9624     usecs:     751.86
+frequent/fixnum    bytes:     1680     usecs:      42.50
+frequent/float     bytes:     1200     usecs:      30.72
+frequent/list      bytes:     2160     usecs:      55.72
+frequent/vector    bytes:      240     usecs:       6.36
 
 Perf Metrics Summary: prelude
 --------------------
-prelude/closure    bytes:    20904     usecs:   15564.85
-prelude/compile    bytes:    38856     usecs:   29492.35
-prelude/prelude    bytes:     4592     usecs:     287.25
-prelude/exception  bytes:     6920     usecs:    5616.00
-prelude/fixnum     bytes:     2000     usecs:     174.90
-prelude/format     bytes:     6144     usecs:    6895.85
-prelude/lambda     bytes:    97784     usecs:   74196.55
-prelude/list       bytes:    20864     usecs:   10383.70
-prelude/macro      bytes:    58416     usecs:   48784.25
-prelude/reader     bytes:    15032     usecs:  120318.85
-prelude/stream     bytes:      960     usecs:      72.60
-prelude/string     bytes:     2160     usecs:     603.65
-prelude/type       bytes:     8768     usecs:    6797.75
-prelude/vector     bytes:     9472     usecs:    7614.10
+prelude/closure    bytes:    20904     usecs:   19704.08
+prelude/compile    bytes:    38856     usecs:   37693.90
+prelude/prelude    bytes:     4592     usecs:     328.42
+prelude/exception  bytes:     6896     usecs:    7098.38
+prelude/fixnum     bytes:     2000     usecs:     209.38
+prelude/format     bytes:     6144     usecs:    8703.12
+prelude/lambda     bytes:    97784     usecs:   94466.36
+prelude/list       bytes:    20864     usecs:   12723.60
+prelude/macro      bytes:    58416     usecs:   61200.08
+prelude/reader     bytes:    15032     usecs:  151433.08
+prelude/stream     bytes:      960     usecs:      80.08
+prelude/string     bytes:     2160     usecs:     723.70
+prelude/type       bytes:     8768     usecs:    8245.38
+prelude/vector     bytes:     9472     usecs:    9415.42
 

--- a/src/libcore/allocators/bump_allocator.rs
+++ b/src/libcore/allocators/bump_allocator.rs
@@ -176,6 +176,9 @@ impl BumpAllocator {
 
                         alloc_type.free -= 1;
 
+                        drop(alloc_ref);
+                        drop(alloc_type);
+
                         return Some(self.free_map[id as usize].remove(index));
                     }
                 }

--- a/src/libcore/core/allocator.rs
+++ b/src/libcore/core/allocator.rs
@@ -3,6 +3,7 @@
 
 //! env allocators
 //!    Env
+use futures::executor::block_on;
 use {
     crate::{
         allocators::{bump_allocator::BumpAllocator, stack_allocator::StackAllocator},
@@ -15,8 +16,6 @@ use {
     modular_bitfield::specifiers::{B11, B4},
     std::fmt,
 };
-
-use futures::executor::block_on;
 
 #[bitfield]
 #[repr(align(8))]

--- a/src/libcore/core/direct.rs
+++ b/src/libcore/core/direct.rs
@@ -109,16 +109,15 @@ impl DirectTag {
     }
 
     pub fn cons(car: Tag, cdr: Tag) -> Option<Tag> {
-        match Self::sext_from_tag(car) {
-            Some(car_) => Self::sext_from_tag(cdr).map(|cdr_| {
-                Self::to_direct(
-                    (car_ as u64) << 28 | cdr_ as u64,
-                    DirectInfo::ExtType(ExtType::Cons),
-                    DirectType::Ext,
-                )
-            }),
-            None => None,
-        }
+        let car_ = Self::sext_from_tag(car)?;
+
+        Self::sext_from_tag(cdr).map(|cdr_| {
+            Self::to_direct(
+                (car_ as u64) << 28 | cdr_ as u64,
+                DirectInfo::ExtType(ExtType::Cons),
+                DirectType::Ext,
+            )
+        })
     }
 
     pub fn car(cons: Tag) -> Tag {

--- a/src/libcore/core/env.rs
+++ b/src/libcore/core/env.rs
@@ -113,10 +113,9 @@ impl Core for Env {
             .map(|cons| self.eval(Cons::car(self, cons)))
             .collect();
 
-        match eval_results {
-            Ok(argv) => Frame { func, argv, value }.apply(self, func),
-            Err(e) => Err(e),
-        }
+        let argv = eval_results?;
+
+        Frame { func, argv, value }.apply(self, func)
     }
 
     fn eval(&self, expr: Tag) -> exception::Result<Tag> {
@@ -124,6 +123,7 @@ impl Core for Env {
             Type::Cons => {
                 let func = Cons::car(self, expr);
                 let args = Cons::cdr(self, expr);
+
                 match func.type_of() {
                     Type::Keyword if func.eq_(&Symbol::keyword("quote")) => {
                         Ok(Cons::car(self, args))

--- a/src/libcore/core/gc.rs
+++ b/src/libcore/core/gc.rs
@@ -63,7 +63,9 @@ impl Core for Env {
 
         Frame::gc_lexical(self);
 
-        let _ = root_ref.iter().map(|tag| Self::mark(self, *tag));
+        for tag in &*root_ref {
+            Self::mark(self, *tag)
+        }
 
         {
             let mut heap_ref = block_on(self.heap.write());
@@ -122,9 +124,9 @@ pub trait CoreFunction {
 
 impl CoreFunction for Gc {
     fn core_gc(env: &Env, fp: &mut Frame) -> exception::Result<()> {
-        fp.value = match env.gc() {
-            Ok(_) => Symbol::keyword("t"),
-            Err(e) => return Err(e),
+        fp.value = {
+            env.gc()?;
+            Symbol::keyword("t")
         };
 
         Ok(())

--- a/src/libcore/core/heap.rs
+++ b/src/libcore/core/heap.rs
@@ -104,6 +104,7 @@ impl CoreFunction for Heap {
         }
 
         fp.value = TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env);
+
         Ok(())
     }
 
@@ -117,6 +118,7 @@ impl CoreFunction for Heap {
         ];
 
         fp.value = TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env);
+
         Ok(())
     }
 

--- a/src/libcore/core/utime.rs
+++ b/src/libcore/core/utime.rs
@@ -7,21 +7,10 @@ use crate::{
         env::Env,
         exception::{self},
         frame::Frame,
-        types::Tag,
     },
     types::fixnum::Fixnum,
 };
 use cpu_time::ProcessTime;
-
-pub trait Core {
-    fn utime(_: &Env, _: String) -> exception::Result<Tag>;
-}
-
-impl Core for Env {
-    fn utime(_: &Env, _: String) -> exception::Result<Tag> {
-        Ok(Tag::nil())
-    }
-}
 
 pub trait CoreFunction {
     fn core_utime(_: &Env, _: &mut Frame) -> exception::Result<()>;
@@ -30,11 +19,11 @@ pub trait CoreFunction {
 impl CoreFunction for Env {
     fn core_utime(env: &Env, fp: &mut Frame) -> exception::Result<()> {
         fp.value = match ProcessTime::try_now() {
-            Err(_) => panic!(),
             Ok(_) => match env.start_time.try_elapsed() {
-                Err(_) => panic!(),
                 Ok(delta) => Fixnum::as_tag(delta.as_micros() as i64),
+                Err(_) => panic!(),
             },
+            Err(_) => panic!(),
         };
 
         Ok(())

--- a/src/libcore/streams/read.rs
+++ b/src/libcore/streams/read.rs
@@ -42,27 +42,23 @@ impl Core for Env {
         eof_value: Tag,
         recursivep: bool,
     ) -> exception::Result<Tag> {
-        match Lib::read_ws(self, stream) {
-            Ok(None) => {
-                return if eof_error_p {
-                    Err(Exception::new(self, Condition::Eof, "core:read", stream))
-                } else {
-                    Ok(eof_value)
-                }
-            }
-            Ok(_) => (),
-            Err(e) => return Err(e),
+        if Lib::read_ws(self, stream)?.is_none() {
+            return if eof_error_p {
+                Err(Exception::new(self, Condition::Eof, "core:read", stream))
+            } else {
+                Ok(eof_value)
+            };
         };
 
-        match Stream::read_char(self, stream) {
-            Ok(None) => {
+        match Stream::read_char(self, stream)? {
+            None => {
                 if eof_error_p {
                     Err(Exception::new(self, Condition::Eof, "core:read", stream))
                 } else {
                     Ok(eof_value)
                 }
             }
-            Ok(Some(ch)) => match map_char_syntax(ch) {
+            Some(ch) => match map_char_syntax(ch) {
                 Some(stype) => match stype {
                     SyntaxType::Constituent => Lib::read_atom(self, ch, stream),
                     SyntaxType::Macro => match ch {
@@ -136,7 +132,6 @@ impl Core for Env {
                     Tag::from(ch),
                 )),
             },
-            Err(e) => Err(e),
         }
     }
 }

--- a/src/libcore/types/char.rs
+++ b/src/libcore/types/char.rs
@@ -54,23 +54,19 @@ impl Core for Char {
 
             let phrase = match ch {
                 0x20 => "space",
-                0x9 => "tab",
-                0xa => "linefeed",
-                0xc => "page",
-                0xd => "return",
+                0x09 => "tab",
+                0x0a => "linefeed",
+                0x0c => "page",
+                0x0d => "return",
                 _ => (ch as char).encode_utf8(&mut tmp),
             };
 
-            match env.write_string(phrase, stream) {
-                Ok(_) => Ok(()),
-                Err(e) => Err(e),
-            }
+            env.write_string(phrase, stream)?;
         } else {
-            match Stream::write_char(env, stream, ch as char) {
-                Ok(_) => Ok(()),
-                Err(e) => Err(e),
-            }
+            Stream::write_char(env, stream, ch as char)?;
         }
+
+        Ok(())
     }
 
     fn view(env: &Env, chr: Tag) -> Tag {

--- a/src/libcore/types/fixnum.rs
+++ b/src/libcore/types/fixnum.rs
@@ -102,30 +102,27 @@ pub trait CoreFunction {
 
 impl CoreFunction for Fixnum {
     fn core_ash(env: &Env, fp: &mut Frame) -> exception::Result<()> {
-        fp.value = match env.fp_argv_check("core:ash", &[Type::Fixnum, Type::Fixnum], fp) {
-            Ok(_) => {
-                let value = Self::as_i64(fp.argv[0]);
-                let shift = Self::as_i64(fp.argv[1]);
+        env.fp_argv_check("core:ash", &[Type::Fixnum, Type::Fixnum], fp)?;
 
-                let result = if shift < 0 {
-                    value >> shift.abs()
-                } else {
-                    value << shift
-                };
+        let value = Self::as_i64(fp.argv[0]);
+        let shift = Self::as_i64(fp.argv[1]);
 
-                if Self::is_i56(result) {
-                    Self::as_tag(result)
-                } else {
-                    return Err(Exception::new(
-                        env,
-                        Condition::Over,
-                        "core:ash",
-                        Cons::new(fp.argv[0], fp.argv[1]).evict(env),
-                    ));
-                }
-            }
-            Err(e) => return Err(e),
+        let result = if shift < 0 {
+            value >> shift.abs()
+        } else {
+            value << shift
         };
+
+        if Self::is_i56(result) {
+            fp.value = Self::as_tag(result)
+        } else {
+            return Err(Exception::new(
+                env,
+                Condition::Over,
+                "core:ash",
+                Cons::new(fp.argv[0], fp.argv[1]).evict(env),
+            ));
+        }
 
         Ok(())
     }
@@ -134,18 +131,17 @@ impl CoreFunction for Fixnum {
         let fx0 = fp.argv[0];
         let fx1 = fp.argv[1];
 
-        fp.value = match env.fp_argv_check("core:fx-add", &[Type::Fixnum, Type::Fixnum], fp) {
-            Ok(_) => match Self::as_i64(fx0).checked_add(Self::as_i64(fx1)) {
-                Some(sum) => {
-                    if Self::is_i56(sum) {
-                        Self::as_tag(sum)
-                    } else {
-                        return Err(Exception::new(env, Condition::Over, "core:fx-add", fx0));
-                    }
+        env.fp_argv_check("core:sum", &[Type::Fixnum, Type::Fixnum], fp)?;
+
+        fp.value = match Self::as_i64(fx0).checked_add(Self::as_i64(fx1)) {
+            Some(sum) => {
+                if Self::is_i56(sum) {
+                    Self::as_tag(sum)
+                } else {
+                    return Err(Exception::new(env, Condition::Over, "core:sum", fx0));
                 }
-                None => return Err(Exception::new(env, Condition::Over, "core:fx-add", fx1)),
-            },
-            Err(e) => return Err(e),
+            }
+            None => return Err(Exception::new(env, Condition::Over, "core:sum", fx1)),
         };
 
         Ok(())
@@ -155,18 +151,17 @@ impl CoreFunction for Fixnum {
         let fx0 = fp.argv[0];
         let fx1 = fp.argv[1];
 
-        fp.value = match env.fp_argv_check("core:fx-sub", &[Type::Fixnum, Type::Fixnum], fp) {
-            Ok(_) => match Self::as_i64(fx0).checked_sub(Self::as_i64(fx1)) {
-                Some(diff) => {
-                    if Self::is_i56(diff) {
-                        Self::as_tag(diff)
-                    } else {
-                        return Err(Exception::new(env, Condition::Over, "core:fx-sub", fx1));
-                    }
+        env.fp_argv_check("core:difference", &[Type::Fixnum, Type::Fixnum], fp)?;
+
+        fp.value = match Self::as_i64(fx0).checked_sub(Self::as_i64(fx1)) {
+            Some(diff) => {
+                if Self::is_i56(diff) {
+                    Self::as_tag(diff)
+                } else {
+                    return Err(Exception::new(env, Condition::Over, "core:difference", fx1));
                 }
-                None => return Err(Exception::new(env, Condition::Over, "core:fx-sub", fx1)),
-            },
-            Err(e) => return Err(e),
+            }
+            None => return Err(Exception::new(env, Condition::Over, "core:difference", fx1)),
         };
 
         Ok(())
@@ -176,18 +171,17 @@ impl CoreFunction for Fixnum {
         let fx0 = fp.argv[0];
         let fx1 = fp.argv[1];
 
-        fp.value = match env.fp_argv_check("core:fx-mul", &[Type::Fixnum, Type::Fixnum], fp) {
-            Ok(_) => match Self::as_i64(fx0).checked_mul(Self::as_i64(fx1)) {
-                Some(prod) => {
-                    if Self::is_i56(prod) {
-                        Self::as_tag(prod)
-                    } else {
-                        return Err(Exception::new(env, Condition::Over, "core:fx-mul", fx1));
-                    }
+        env.fp_argv_check("core:product", &[Type::Fixnum, Type::Fixnum], fp)?;
+
+        fp.value = match Self::as_i64(fx0).checked_mul(Self::as_i64(fx1)) {
+            Some(prod) => {
+                if Self::is_i56(prod) {
+                    Self::as_tag(prod)
+                } else {
+                    return Err(Exception::new(env, Condition::Over, "core:product", fx1));
                 }
-                None => return Err(Exception::new(env, Condition::Over, "core:fx-mul", fx1)),
-            },
-            Err(e) => return Err(e),
+            }
+            None => return Err(Exception::new(env, Condition::Over, "core:product", fx1)),
         };
 
         Ok(())
@@ -197,29 +191,26 @@ impl CoreFunction for Fixnum {
         let fx0 = fp.argv[0];
         let fx1 = fp.argv[1];
 
-        fp.value = match env.fp_argv_check("core:fx-div", &[Type::Fixnum, Type::Fixnum], fp) {
-            Ok(_) => {
-                if Self::as_i64(fx1) == 0 {
-                    return Err(Exception::new(
-                        env,
-                        Condition::ZeroDivide,
-                        "core:fx-div",
-                        fx0,
-                    ));
-                }
+        env.fp_argv_check("core:quotient", &[Type::Fixnum, Type::Fixnum], fp)?;
 
-                match Self::as_i64(fx0).checked_div(Self::as_i64(fx1)) {
-                    Some(div) => {
-                        if Self::is_i56(div) {
-                            Self::as_tag(div)
-                        } else {
-                            return Err(Exception::new(env, Condition::Over, "core:fx-div", fx1));
-                        }
-                    }
-                    None => return Err(Exception::new(env, Condition::Over, "core:fx-div", fx1)),
+        if Self::as_i64(fx1) == 0 {
+            return Err(Exception::new(
+                env,
+                Condition::ZeroDivide,
+                "core:fx-div",
+                fx0,
+            ));
+        }
+
+        fp.value = match Self::as_i64(fx0).checked_div(Self::as_i64(fx1)) {
+            Some(div) => {
+                if Self::is_i56(div) {
+                    Self::as_tag(div)
+                } else {
+                    return Err(Exception::new(env, Condition::Over, "core:quotient", fx1));
                 }
             }
-            Err(e) => return Err(e),
+            None => return Err(Exception::new(env, Condition::Over, "core:quotient", fx1)),
         };
 
         Ok(())
@@ -229,15 +220,12 @@ impl CoreFunction for Fixnum {
         let fx0 = fp.argv[0];
         let fx1 = fp.argv[1];
 
-        fp.value = match env.fp_argv_check("core:fx-lt", &[Type::Fixnum, Type::Fixnum], fp) {
-            Ok(_) => {
-                if Self::as_i64(fx0) < Self::as_i64(fx1) {
-                    Symbol::keyword("t")
-                } else {
-                    Tag::nil()
-                }
-            }
-            Err(e) => return Err(e),
+        env.fp_argv_check("core:less-than", &[Type::Fixnum, Type::Fixnum], fp)?;
+
+        fp.value = if Self::as_i64(fx0) < Self::as_i64(fx1) {
+            Symbol::keyword("t")
+        } else {
+            Tag::nil()
         };
 
         Ok(())
@@ -247,10 +235,8 @@ impl CoreFunction for Fixnum {
         let fx0 = fp.argv[0];
         let fx1 = fp.argv[1];
 
-        fp.value = match env.fp_argv_check("core:logand", &[Type::Fixnum, Type::Fixnum], fp) {
-            Ok(_) => Self::as_tag(Self::as_i64(fx0) & Self::as_i64(fx1)),
-            Err(e) => return Err(e),
-        };
+        env.fp_argv_check("core:logand", &[Type::Fixnum, Type::Fixnum], fp)?;
+        fp.value = Self::as_tag(Self::as_i64(fx0) & Self::as_i64(fx1));
 
         Ok(())
     }
@@ -259,10 +245,8 @@ impl CoreFunction for Fixnum {
         let fx0 = fp.argv[0];
         let fx1 = fp.argv[1];
 
-        fp.value = match env.fp_argv_check("core:logor", &[Type::Fixnum, Type::Fixnum], fp) {
-            Ok(_) => Self::as_tag(Self::as_i64(fx0) | Self::as_i64(fx1)),
-            Err(e) => return Err(e),
-        };
+        env.fp_argv_check("core:logor", &[Type::Fixnum, Type::Fixnum], fp)?;
+        fp.value = Self::as_tag(Self::as_i64(fx0) | Self::as_i64(fx1));
 
         Ok(())
     }
@@ -270,22 +254,20 @@ impl CoreFunction for Fixnum {
     fn core_lognot(env: &Env, fp: &mut Frame) -> exception::Result<()> {
         let fx = fp.argv[0];
 
-        fp.value = match env.fp_argv_check("core:lognot", &[Type::Fixnum], fp) {
-            Ok(_) => {
-                let mut val = Self::as_i64(fx);
-                for nth_bit in 0..64 {
-                    let mask = 1 << nth_bit;
-                    if val & mask == 0 {
-                        val |= mask
-                    } else {
-                        val &= !mask
-                    }
-                }
+        env.fp_argv_check("core:lognot", &[Type::Fixnum], fp)?;
 
-                Self::as_tag(val)
+        let mut val = Self::as_i64(fx);
+        for nth_bit in 0..64 {
+            let mask = 1 << nth_bit;
+
+            if val & mask == 0 {
+                val |= mask
+            } else {
+                val &= !mask
             }
-            Err(e) => return Err(e),
-        };
+        }
+
+        fp.value = Self::as_tag(val);
 
         Ok(())
     }

--- a/src/libcore/types/float.rs
+++ b/src/libcore/types/float.rs
@@ -95,17 +95,14 @@ impl CoreFunction for Float {
         let fl0 = fp.argv[0];
         let fl1 = fp.argv[1];
 
-        fp.value = match env.fp_argv_check("core:fl-add", &[Type::Float, Type::Float], fp) {
-            Ok(_) => {
-                let sum = Self::as_f32(env, fl0).add(Self::as_f32(env, fl1));
-                if sum.is_nan() {
-                    return Err(Exception::new(env, Condition::Over, "core:fl-add", fl1));
-                } else {
-                    Self::as_tag(sum)
-                }
-            }
-            Err(e) => return Err(e),
-        };
+        env.fp_argv_check("core:fl-add", &[Type::Float, Type::Float], fp)?;
+
+        let sum = Self::as_f32(env, fl0).add(Self::as_f32(env, fl1));
+        if sum.is_nan() {
+            return Err(Exception::new(env, Condition::Over, "core:fl-add", fl1));
+        } else {
+            fp.value = Self::as_tag(sum)
+        }
 
         Ok(())
     }
@@ -114,17 +111,14 @@ impl CoreFunction for Float {
         let fl0 = fp.argv[0];
         let fl1 = fp.argv[1];
 
-        fp.value = match env.fp_argv_check("core:fl-sub", &[Type::Float, Type::Float], fp) {
-            Ok(_) => {
-                let diff = Self::as_f32(env, fl0).sub(Self::as_f32(env, fl1));
-                if diff.is_nan() {
-                    return Err(Exception::new(env, Condition::Under, "core:fl-sub", fl1));
-                } else {
-                    Self::as_tag(diff)
-                }
-            }
-            Err(e) => return Err(e),
-        };
+        env.fp_argv_check("core:fl-sub", &[Type::Float, Type::Float], fp)?;
+
+        let diff = Self::as_f32(env, fl0).sub(Self::as_f32(env, fl1));
+        if diff.is_nan() {
+            return Err(Exception::new(env, Condition::Under, "core:fl-sub", fl1));
+        } else {
+            fp.value = Self::as_tag(diff)
+        }
 
         Ok(())
     }
@@ -133,18 +127,14 @@ impl CoreFunction for Float {
         let fl0 = fp.argv[0];
         let fl1 = fp.argv[1];
 
-        fp.value = match env.fp_argv_check("core:fl-envl", &[Type::Float, Type::Float], fp) {
-            Ok(_) => {
-                let prod = Self::as_f32(env, fl0).mul(Self::as_f32(env, fl1));
+        env.fp_argv_check("core:fl-mul", &[Type::Float, Type::Float], fp)?;
 
-                if prod.is_nan() {
-                    return Err(Exception::new(env, Condition::Over, "core:fl-mul", fl1));
-                } else {
-                    Self::as_tag(prod)
-                }
-            }
-            Err(e) => return Err(e),
-        };
+        let prod = Self::as_f32(env, fl0).mul(Self::as_f32(env, fl1));
+        if prod.is_nan() {
+            return Err(Exception::new(env, Condition::Over, "core:fl-mul", fl1));
+        } else {
+            fp.value = Self::as_tag(prod)
+        }
 
         Ok(())
     }
@@ -153,20 +143,18 @@ impl CoreFunction for Float {
         let fl0 = fp.argv[0];
         let fl1 = fp.argv[1];
 
-        fp.value = match env.fp_argv_check("core:fl-div", &[Type::Float, Type::Float], fp) {
-            Ok(_) => {
-                if Self::as_f32(env, fl1) == 0.0 {
-                    return Err(Exception::new(env, Condition::ZeroDivide, "fl-div", fl1));
-                }
+        env.fp_argv_check("core:fl-div", &[Type::Float, Type::Float], fp)?;
 
-                let div = Self::as_f32(env, fl0).div(Self::as_f32(env, fl1));
-                if div.is_nan() {
-                    return Err(Exception::new(env, Condition::Under, "core:fl-div", fl1));
-                } else {
-                    Self::as_tag(div)
-                }
-            }
-            Err(e) => return Err(e),
+        if Self::as_f32(env, fl1) == 0.0 {
+            return Err(Exception::new(env, Condition::ZeroDivide, "fl-div", fl1));
+        }
+
+        let div = Self::as_f32(env, fl0).div(Self::as_f32(env, fl1));
+
+        fp.value = if div.is_nan() {
+            return Err(Exception::new(env, Condition::Under, "core:fl-div", fl1));
+        } else {
+            Self::as_tag(div)
         };
 
         Ok(())
@@ -176,15 +164,11 @@ impl CoreFunction for Float {
         let fl0 = fp.argv[0];
         let fl1 = fp.argv[1];
 
-        fp.value = match env.fp_argv_check("core:fl-lt", &[Type::Float, Type::Float], fp) {
-            Ok(_) => {
-                if Self::as_f32(env, fl0) < Self::as_f32(env, fl1) {
-                    Symbol::keyword("t")
-                } else {
-                    Tag::nil()
-                }
-            }
-            Err(e) => return Err(e),
+        env.fp_argv_check("core:fl-lt", &[Type::Float, Type::Float], fp)?;
+        fp.value = if Self::as_f32(env, fl0) < Self::as_f32(env, fl1) {
+            Symbol::keyword("t")
+        } else {
+            Tag::nil()
         };
 
         Ok(())

--- a/src/libcore/types/struct_.rs
+++ b/src/libcore/types/struct_.rs
@@ -209,10 +209,8 @@ impl CoreFunction for Struct {
     fn core_struct_type(env: &Env, fp: &mut Frame) -> exception::Result<()> {
         let tag = fp.argv[0];
 
-        fp.value = match env.fp_argv_check("core:struct-type", &[Type::Struct], fp) {
-            Ok(_) => Self::to_image(env, tag).stype,
-            Err(e) => return Err(e),
-        };
+        env.fp_argv_check("core:struct-type", &[Type::Struct], fp)?;
+        fp.value = Self::to_image(env, tag).stype;
 
         Ok(())
     }
@@ -220,10 +218,8 @@ impl CoreFunction for Struct {
     fn core_struct_vector(env: &Env, fp: &mut Frame) -> exception::Result<()> {
         let tag = fp.argv[0];
 
-        fp.value = match env.fp_argv_check("core:struct-vec", &[Type::Struct], fp) {
-            Ok(_) => Self::to_image(env, tag).vector,
-            Err(e) => return Err(e),
-        };
+        env.fp_argv_check("core:struct-vec", &[Type::Struct], fp)?;
+        fp.value = Self::to_image(env, tag).vector;
 
         Ok(())
     }
@@ -232,17 +228,15 @@ impl CoreFunction for Struct {
         let stype = fp.argv[0];
         let list = fp.argv[1];
 
-        fp.value = match env.fp_argv_check("core:make-struct", &[Type::Keyword, Type::List], fp) {
-            Ok(_) => {
-                let vec = Cons::iter(env, list)
-                    .map(|cons| Cons::car(env, cons))
-                    .collect::<Vec<Tag>>();
-                let vector = TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env);
+        env.fp_argv_check("core:make-struct", &[Type::Keyword, Type::List], fp)?;
 
-                Struct { stype, vector }.evict(env)
-            }
-            Err(e) => return Err(e),
-        };
+        let vec = Cons::iter(env, list)
+            .map(|cons| Cons::car(env, cons))
+            .collect::<Vec<Tag>>();
+
+        let vector = TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env);
+
+        fp.value = Struct { stype, vector }.evict(env);
 
         Ok(())
     }

--- a/src/libcore/types/symbol.rs
+++ b/src/libcore/types/symbol.rs
@@ -68,21 +68,23 @@ impl Symbol {
     }
 
     pub fn to_image(env: &Env, tag: Tag) -> SymbolImage {
-        let heap_ref = block_on(env.heap.read());
-
         match tag.type_of() {
             Type::Symbol => match tag {
-                Tag::Indirect(main) => SymbolImage {
-                    namespace: Tag::from_slice(
-                        heap_ref.image_slice(main.image_id() as usize).unwrap(),
-                    ),
-                    name: Tag::from_slice(
-                        heap_ref.image_slice(main.image_id() as usize + 1).unwrap(),
-                    ),
-                    value: Tag::from_slice(
-                        heap_ref.image_slice(main.image_id() as usize + 2).unwrap(),
-                    ),
-                },
+                Tag::Indirect(main) => {
+                    let heap_ref = block_on(env.heap.read());
+
+                    SymbolImage {
+                        namespace: Tag::from_slice(
+                            heap_ref.image_slice(main.image_id() as usize).unwrap(),
+                        ),
+                        name: Tag::from_slice(
+                            heap_ref.image_slice(main.image_id() as usize + 1).unwrap(),
+                        ),
+                        value: Tag::from_slice(
+                            heap_ref.image_slice(main.image_id() as usize + 2).unwrap(),
+                        ),
+                    }
+                }
                 _ => panic!(),
             },
             _ => panic!(),

--- a/tests/core/stream
+++ b/tests/core/stream
@@ -1,5 +1,5 @@
 (core:close core:error-output)	:t
-(core:flush core:standard-output)	:nil
+(core:type-of (core:flush core:standard-output))	:stream
 (core:get-string (core:open :string :output "abcdef"))	"abcdef"
 (core:openp core:error-output)	#<stream: 2 :error-output :output :open>
 (core:write "abc" () core:standard-output)	abc"abc"


### PR DESCRIPTION
convert a bunch of Result/Option function calls to ? syntax

significantly reduces code complexity

docs: no change
tests: change to core/stream, correct return type of flush
regression: odd reduction of 24 bytes in a single exception test, times stayed the same
srcs: just about every file in libcore changed
