### PR TITLE
#263 - libcore: reorganize heap locking

### DIFF
--- a/metrics/regression/current.summary
+++ b/metrics/regression/current.summary
@@ -1,40 +1,40 @@
 Perf Metrics Summary: core
 --------------------
-core/compile       bytes:     1520     usecs:      49.96
-core/core          bytes:     5808     usecs:     179.82
-core/gcd           bytes:      624     usecs:     168.18
-core/list          bytes:     5296     usecs:     138.74
-core/namespace     bytes:      240     usecs:       4.90
-core/number        bytes:     3600     usecs:      92.22
-core/reader        bytes:     5280     usecs:     120.96
-core/special-form  bytes:     2400     usecs:      71.92
-core/stream        bytes:      480     usecs:      15.10
-core/struct        bytes:      576     usecs:      15.22
-core/symbol        bytes:     1200     usecs:      32.04
-core/vector        bytes:     4456     usecs:     118.40
+core/compile       bytes:     1520     usecs:      51.70
+core/core          bytes:     5808     usecs:     198.80
+core/gcd           bytes:      624     usecs:     141.00
+core/list          bytes:     5296     usecs:     170.85
+core/namespace     bytes:      240     usecs:       5.70
+core/number        bytes:     3600     usecs:     104.95
+core/reader        bytes:     5280     usecs:     142.85
+core/special-form  bytes:     2400     usecs:      82.85
+core/stream        bytes:      480     usecs:      16.65
+core/struct        bytes:      576     usecs:      16.15
+core/symbol        bytes:     1200     usecs:      35.75
+core/vector        bytes:     4456     usecs:     132.75
 
 Perf Metrics Summary: frequent
 --------------------
-frequent/core      bytes:     9624     usecs:     751.86
-frequent/fixnum    bytes:     1680     usecs:      42.50
-frequent/float     bytes:     1200     usecs:      30.72
-frequent/list      bytes:     2160     usecs:      55.72
-frequent/vector    bytes:      240     usecs:       6.36
+frequent/core      bytes:     9624     usecs:     701.80
+frequent/fixnum    bytes:     1680     usecs:      50.10
+frequent/float     bytes:     1200     usecs:      36.15
+frequent/list      bytes:     2160     usecs:      72.25
+frequent/vector    bytes:      240     usecs:       7.10
 
 Perf Metrics Summary: prelude
 --------------------
-prelude/closure    bytes:    20904     usecs:   19704.08
-prelude/compile    bytes:    38856     usecs:   37693.90
-prelude/prelude    bytes:     4592     usecs:     328.42
-prelude/exception  bytes:     6896     usecs:    7098.38
-prelude/fixnum     bytes:     2000     usecs:     209.38
-prelude/format     bytes:     6144     usecs:    8703.12
-prelude/lambda     bytes:    97784     usecs:   94466.36
-prelude/list       bytes:    20864     usecs:   12723.60
-prelude/macro      bytes:    58416     usecs:   61200.08
-prelude/reader     bytes:    15032     usecs:  151433.08
-prelude/stream     bytes:      960     usecs:      80.08
-prelude/string     bytes:     2160     usecs:     723.70
-prelude/type       bytes:     8768     usecs:    8245.38
-prelude/vector     bytes:     9472     usecs:    9415.42
+prelude/closure    bytes:    20904     usecs:   15432.50
+prelude/compile    bytes:    38856     usecs:   29437.30
+prelude/prelude    bytes:     4592     usecs:     272.70
+prelude/exception  bytes:     6896     usecs:    5601.15
+prelude/fixnum     bytes:     2000     usecs:     167.75
+prelude/format     bytes:     6144     usecs:    6845.35
+prelude/lambda     bytes:    97784     usecs:   73795.80
+prelude/list       bytes:    20864     usecs:   10361.00
+prelude/macro      bytes:    58416     usecs:   49002.70
+prelude/reader     bytes:    15032     usecs:  121548.65
+prelude/stream     bytes:      960     usecs:      70.15
+prelude/string     bytes:     2160     usecs:     597.20
+prelude/type       bytes:     8768     usecs:    6697.50
+prelude/vector     bytes:     9472     usecs:    7684.15
 

--- a/src/libcore/core/env.rs
+++ b/src/libcore/core/env.rs
@@ -28,6 +28,8 @@ use {
 // locking protocols
 use futures_locks::RwLock;
 
+pub type HeapRef<'a> = &'a mut futures_locks::RwLockWriteGuard<BumpAllocator>;
+
 // env environment
 pub struct Env {
     // configuration

--- a/src/libcore/core/reader.rs
+++ b/src/libcore/core/reader.rs
@@ -226,8 +226,8 @@ impl Core for Lib {
                         SyntaxType::Whitespace => Ok(Some(Tag::from(ch))),
                         SyntaxType::Constituent => {
                             Stream::unread_char(env, stream, space).unwrap();
-                            match Self::read_token(env, stream) {
-                                Ok(Some(str)) => {
+                            match Self::read_token(env, stream)? {
+                                Some(str) => {
                                     let phrase = ch.to_string() + &str;
                                     match phrase.as_str() {
                                         "tab" => Ok(Some(Tag::from('\t'))),
@@ -243,10 +243,9 @@ impl Core for Lib {
                                         )),
                                     }
                                 }
-                                Ok(None) => {
+                                None => {
                                     Err(Exception::new(env, Condition::Eof, "core:read", stream))
                                 }
-                                Err(e) => Err(e),
                             }
                         }
                         _ => {

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -157,14 +157,12 @@ impl Env {
         let env_ref = block_on(LIB.env_map.read());
         let env = env_ref.get(&self.0.as_u64()).unwrap();
 
-        match StreamBuilder::new()
+        let stream = StreamBuilder::new()
             .string(str.to_string())
             .input()
-            .build(env, &LIB)
-        {
-            Ok(stream) => env.read_stream(stream, true, Tag::nil(), false),
-            Err(e) => Err(e),
-        }
+            .build(env, &LIB)?;
+
+        env.read_stream(stream, true, Tag::nil(), false)
     }
 
     /// write an s-expression to a lib stream
@@ -225,13 +223,7 @@ impl Env {
         let env_ref = block_on(LIB.env_map.read());
         let env = env_ref.get(&self.0.as_u64()).unwrap();
 
-        match self.read_str(expr) {
-            Ok(expr) => match self.compile(expr) {
-                Ok(expr) => env.eval(expr),
-                Err(e) => Err(e),
-            },
-            Err(e) => Err(e),
-        }
+        env.eval(self.compile(self.read_str(expr)?)?)
     }
 
     /// format exception

--- a/src/libcore/types/core_stream.rs
+++ b/src/libcore/types/core_stream.rs
@@ -206,12 +206,9 @@ impl Core for Stream {
                 }
 
                 if stream.unch.null_() {
-                    match stream.system.read_byte(env) {
-                        Ok(opt) => match opt {
-                            Some(byte) => Ok(Some(byte as char)),
-                            None => Ok(None),
-                        },
-                        Err(e) => Err(e),
+                    match stream.system.read_byte(env)? {
+                        Some(byte) => Ok(Some(byte as char)),
+                        None => Ok(None),
                     }
                 } else {
                     let unch = stream.unch;
@@ -248,12 +245,9 @@ impl Core for Stream {
                 }
 
                 if stream.unch.null_() {
-                    match stream.system.read_byte(env) {
-                        Ok(opt) => match opt {
-                            Some(byte) => Ok(Some(byte)),
-                            None => Ok(None),
-                        },
-                        Err(e) => Err(e),
+                    match stream.system.read_byte(env)? {
+                        Some(byte) => Ok(Some(byte)),
+                        None => Ok(None),
                     }
                 } else {
                     let unch = stream.unch;


### PR DESCRIPTION
make the Core layer responsible for heap locking and pass the handle to an impl function

need to do a better job of separating Core and impl functions

docs: no change
tests: no change
regression: no change
footprint: no change
srcs: bunch of core and types reorganization, used some more ? where possible.