### PR TITLE
#270 - libcore: clean up specialized vector rat's nest

### DIFF
--- a/metrics/regression/current.summary
+++ b/metrics/regression/current.summary
@@ -1,40 +1,40 @@
 Perf Metrics Summary: core
 --------------------
-core/compile       bytes:     1520     usecs:      49.60
-core/core          bytes:     5808     usecs:     170.35
-core/gcd           bytes:      624     usecs:     169.40
-core/list          bytes:     5296     usecs:     136.00
-core/namespace     bytes:      240     usecs:       4.45
-core/number        bytes:     3600     usecs:      92.30
-core/reader        bytes:     5280     usecs:     119.70
-core/special-form  bytes:     2400     usecs:      70.70
-core/stream        bytes:      480     usecs:      14.75
-core/struct        bytes:      576     usecs:      14.80
-core/symbol        bytes:     1200     usecs:      32.30
-core/vector        bytes:     4456     usecs:     115.20
+core/compile       bytes:     1520     usecs:      49.15
+core/core          bytes:     5808     usecs:     170.85
+core/gcd           bytes:      624     usecs:     162.75
+core/list          bytes:     5296     usecs:     134.60
+core/namespace     bytes:      240     usecs:       4.50
+core/number        bytes:     3600     usecs:      90.35
+core/reader        bytes:     5280     usecs:     119.65
+core/special-form  bytes:     2400     usecs:      70.50
+core/stream        bytes:      480     usecs:      14.60
+core/struct        bytes:      576     usecs:      15.65
+core/symbol        bytes:     1200     usecs:      31.35
+core/vector        bytes:     4456     usecs:     114.45
 
 Perf Metrics Summary: frequent
 --------------------
-frequent/core      bytes:     9624     usecs:     766.75
-frequent/fixnum    bytes:     1680     usecs:      41.30
-frequent/float     bytes:     1200     usecs:      30.65
-frequent/list      bytes:     2160     usecs:      54.20
-frequent/vector    bytes:      240     usecs:       5.95
+frequent/core      bytes:     9624     usecs:     747.60
+frequent/fixnum    bytes:     1680     usecs:      42.05
+frequent/float     bytes:     1200     usecs:      30.60
+frequent/list      bytes:     2160     usecs:      54.10
+frequent/vector    bytes:      240     usecs:       6.00
 
 Perf Metrics Summary: prelude
 --------------------
-prelude/closure    bytes:    20904     usecs:   18817.60
-prelude/compile    bytes:    38856     usecs:   35819.75
-prelude/prelude    bytes:     4592     usecs:     342.85
-prelude/exception  bytes:     6896     usecs:    7028.35
-prelude/fixnum     bytes:     2000     usecs:     217.00
-prelude/format     bytes:     6144     usecs:    8415.30
-prelude/lambda     bytes:    97784     usecs:   92495.65
-prelude/list       bytes:    20864     usecs:   12503.15
-prelude/macro      bytes:    58416     usecs:   60211.75
-prelude/reader     bytes:    15032     usecs:  147066.40
-prelude/stream     bytes:      960     usecs:      86.50
-prelude/string     bytes:     2160     usecs:     740.85
-prelude/type       bytes:     8768     usecs:    8068.10
-prelude/vector     bytes:     9472     usecs:    9047.20
+prelude/closure    bytes:    20904     usecs:   18673.65
+prelude/compile    bytes:    38856     usecs:   35840.20
+prelude/prelude    bytes:     4592     usecs:     365.55
+prelude/exception  bytes:     6896     usecs:    6708.70
+prelude/fixnum     bytes:     2000     usecs:     230.65
+prelude/format     bytes:     6144     usecs:    8418.95
+prelude/lambda     bytes:    97784     usecs:   90865.00
+prelude/list       bytes:    20864     usecs:   12354.40
+prelude/macro      bytes:    58416     usecs:   58138.55
+prelude/reader     bytes:    15032     usecs:  144475.35
+prelude/stream     bytes:      960     usecs:      83.40
+prelude/string     bytes:     2160     usecs:     731.55
+prelude/type       bytes:     8768     usecs:    7946.80
+prelude/vector     bytes:     9472     usecs:    9305.85
 

--- a/src/libcore/lib.rs
+++ b/src/libcore/lib.rs
@@ -2,17 +2,17 @@
 //  SPDX-License-Identifier: MIT
 
 //!
-//! The lib machine is the implementation surface for the [`mu programming environment`].
+//! The core machine is the implementation surface for the [`mu programming environment`].
 //!
-//! As much as is practible, lib's functions and data types resemble Common Lisp in preference to
+//! As much as is practible, core's functions and data types resemble Common Lisp in preference to
 //! Scheme/Clojure in order to be immediately familiar to the traditional LISP programmer.
 //!
-//! lib is an immutable, lexically scoped LISP-1 kernel meant as a porting layer for an ascending
+//! core is an immutable, lexically scoped LISP-1 kernel meant as a porting layer for an ascending
 //! tower of LISP languages. While it is possible to do some useful application work directly in the
-//! lib language, lib defers niceties like macros, closures, and rest functions to a compiler
+//! core language, core defers niceties like macros, closures, and rest functions to a compiler
 //! layered on it. See [`mu programming environment`] for details.
 //!
-//! lib characteristics:
+//! core characteristics:
 //! - mostly-safe Rust
 //! - 64 bit tagged objects
 //! - garbage collected heap
@@ -22,7 +22,7 @@
 //! - s-expression reader/printer
 //! - symbol namespaces
 //!
-//! lib data types:
+//! core data types:
 //!    56 bit fixnums (immediate)
 //!    Lisp-1 symbols
 //!    character, string, and byte streams
@@ -35,7 +35,7 @@
 //!    single float 32 bit IEEE float (immediate)
 //!    structs
 //!
-//! lib documentation:
+//! core documentation:
 //!    see doc/refcards and doc/rustdoc
 //!
 //! [`mu programming environment`]: <https://github.com/Software-Knife-and-Tool/mu>
@@ -73,22 +73,22 @@ use {
     std::fs,
 };
 
-/// The lib API
+/// The core API
 ///
-/// The lib API exposes these types:
+/// The core API exposes these types:
 /// - Condition, enumeration of possible exceptional conditions
 /// - Exception, exception state
 /// - Lib, environment and API namespace
 /// - Result, specialized result for API functions that can fail
 /// - Tag, tagged data representation
 
-/// the tagged data representation
+/// tagged data representation
 pub type Tag = core::types::Tag;
-/// the API function Result
+/// API function Result
 pub type Result = core::exception::Result<Tag>;
-/// the condition enumeration
+/// condition enumeration
 pub type Condition = core::exception::Condition;
-/// the Exception representation
+/// Exception representation
 pub type Exception = core::exception::Exception;
 
 /// the Env struct abstracts the library struct
@@ -144,7 +144,7 @@ impl Env {
         Compile::compile(env, expr, &mut vec![])
     }
 
-    /// read a tagged s-expression from a lib stream
+    /// read a tagged s-expression from a core stream
     pub fn read(&self, stream: Tag, eof_error_p: bool, eof_value: Tag) -> exception::Result<Tag> {
         let env_ref = block_on(LIB.env_map.read());
         let env = env_ref.get(&self.0.as_u64()).unwrap();
@@ -152,7 +152,7 @@ impl Env {
         env.read_stream(stream, eof_error_p, eof_value, false)
     }
 
-    /// convert a rust String to a tagged s-expression
+    /// convert a String to a tagged s-expression
     pub fn read_str(&self, str: &str) -> exception::Result<Tag> {
         let env_ref = block_on(LIB.env_map.read());
         let env = env_ref.get(&self.0.as_u64()).unwrap();
@@ -165,7 +165,7 @@ impl Env {
         env.read_stream(stream, true, Tag::nil(), false)
     }
 
-    /// write an s-expression to a lib stream
+    /// write an s-expression to a core stream
     pub fn write(&self, expr: Tag, escape: bool, stream: Tag) -> exception::Result<()> {
         let env_ref = block_on(LIB.env_map.read());
         let env = env_ref.get(&self.0.as_u64()).unwrap();
@@ -173,7 +173,7 @@ impl Env {
         env.write_stream(expr, escape, stream)
     }
 
-    /// write a rust String to a lib stream
+    /// write a rust String to a core stream
     pub fn write_str(&self, str: &str, stream: Tag) -> exception::Result<()> {
         let env_ref = block_on(LIB.env_map.read());
         let env = env_ref.get(&self.0.as_u64()).unwrap();
@@ -203,17 +203,17 @@ impl Env {
         Stream::get_string(env, str_stream).unwrap()
     }
 
-    /// return the standard-input lib stream
+    /// return the standard-input core stream
     pub fn std_in(&self) -> Tag {
         LIB.stdin()
     }
 
-    /// return the standard-output lib stream
+    /// return the standard-output core stream
     pub fn std_out(&self) -> Tag {
         LIB.stdout()
     }
 
-    /// return the error-output lib stream
+    /// return the error-output core stream
     pub fn err_out(&self) -> Tag {
         LIB.errout()
     }

--- a/src/libcore/types/indirect_vector.rs
+++ b/src/libcore/types/indirect_vector.rs
@@ -2,21 +2,22 @@
 //  SPDX-License-Identifier: MIT
 
 //! typed vectors
-use crate::{
-    core::{
-        direct::{DirectInfo, DirectTag, DirectType},
-        env::Env,
-        indirect::IndirectTag,
-        types::{Tag, TagType, Type},
+use {
+    crate::{
+        core::{
+            direct::{DirectInfo, DirectTag, DirectType},
+            env::Env,
+            indirect::IndirectTag,
+            types::{Tag, TagType, Type},
+        },
+        types::{
+            fixnum::Fixnum,
+            symbol::{Core as _, Symbol},
+            vector::{Core, Vector},
+        },
     },
-    types::{
-        fixnum::Fixnum,
-        symbol::{Core as _, Symbol},
-        vector::{Core, Vector},
-    },
+    futures::executor::block_on,
 };
-
-use futures::executor::block_on;
 
 pub struct VectorImage {
     pub vtype: Tag,  // type keyword
@@ -57,93 +58,55 @@ impl<'a> IVector for IndirectVector<'a> {
     }
 
     fn evict(&self, env: &Env) -> Tag {
-        match self {
-            IndirectVector::Byte(image, ivec) => {
-                let slices = Self::image(image);
+        let mut heap_ref = block_on(env.heap.write());
 
+        let image_id = match self {
+            IndirectVector::Byte(image, ivec) => {
                 let data = match ivec {
                     IVec::Byte(vec_u8) => &vec_u8[..],
                     _ => panic!(),
                 };
 
-                let mut heap_ref = block_on(env.heap.write());
-
-                Tag::Indirect(
-                    IndirectTag::new()
-                        .with_image_id(
-                            heap_ref
-                                .alloc(&slices, Some(data), Type::Vector as u8)
-                                .unwrap() as u64,
-                        )
-                        .with_heap_id(1)
-                        .with_tag(TagType::Vector),
-                )
+                heap_ref
+                    .alloc(&Self::image(image), Some(data), Type::Vector as u8)
+                    .unwrap() as u64
             }
             IndirectVector::Char(image, ivec) => {
-                let slices = Self::image(image);
-
                 let data = match ivec {
                     IVec::Char(string) => string.as_bytes(),
                     _ => panic!(),
                 };
 
-                let mut heap_ref = block_on(env.heap.write());
-
-                Tag::Indirect(
-                    IndirectTag::new()
-                        .with_image_id(
-                            heap_ref
-                                .alloc(&slices, Some(data), Type::Vector as u8)
-                                .unwrap() as u64,
-                        )
-                        .with_heap_id(1)
-                        .with_tag(TagType::Vector),
-                )
+                heap_ref
+                    .alloc(&Self::image(image), Some(data), Type::Vector as u8)
+                    .unwrap() as u64
             }
-            IndirectVector::T(image, vec) => {
+            IndirectVector::T(image, ivec) => {
                 let mut slices = Self::image(image);
 
-                match vec {
+                match ivec {
                     IVec::T(vec) => {
                         slices.extend(vec.iter().map(|tag| tag.as_slice()));
                     }
                     _ => panic!(),
                 }
 
-                let mut heap_ref = block_on(env.heap.write());
-
-                Tag::Indirect(
-                    IndirectTag::new()
-                        .with_image_id(
-                            heap_ref.alloc(&slices, None, Type::Vector as u8).unwrap() as u64
-                        )
-                        .with_heap_id(1)
-                        .with_tag(TagType::Vector),
-                )
+                heap_ref.alloc(&slices, None, Type::Vector as u8).unwrap() as u64
             }
-            IndirectVector::Fixnum(image, vec) => {
+            IndirectVector::Fixnum(image, ivec) => {
                 let mut slices = Self::image(image);
 
-                match vec {
+                match ivec {
                     IVec::Fixnum(vec) => {
                         slices.extend(vec.iter().map(|n| n.to_le_bytes()));
                     }
                     _ => panic!(),
                 }
 
-                let mut heap_ref = block_on(env.heap.write());
-
-                Tag::Indirect(
-                    IndirectTag::new()
-                        .with_image_id(
-                            heap_ref.alloc(&slices, None, Type::Vector as u8).unwrap() as u64
-                        )
-                        .with_heap_id(1)
-                        .with_tag(TagType::Vector),
-                )
+                heap_ref.alloc(&slices, None, Type::Vector as u8).unwrap() as u64
             }
-            IndirectVector::Float(image, vec) => {
-                let data = match vec {
+            IndirectVector::Float(image, ivec) => {
+                let data = match ivec {
                     IVec::Float(vec_u4) => {
                         let mut vec_u8 = Vec::<u8>::new();
                         for float in vec_u4 {
@@ -156,95 +119,72 @@ impl<'a> IVector for IndirectVector<'a> {
                     _ => panic!(),
                 };
 
-                let mut heap_ref = block_on(env.heap.write());
-
-                Tag::Indirect(
-                    IndirectTag::new()
-                        .with_image_id(
-                            heap_ref
-                                .alloc(&Self::image(image), Some(&data), Type::Vector as u8)
-                                .unwrap() as u64,
-                        )
-                        .with_heap_id(1)
-                        .with_tag(TagType::Vector),
-                )
+                heap_ref
+                    .alloc(&Self::image(image), Some(&data), Type::Vector as u8)
+                    .unwrap() as u64
             }
-        }
+        };
+
+        Tag::Indirect(
+            IndirectTag::new()
+                .with_image_id(image_id)
+                .with_heap_id(1)
+                .with_tag(TagType::Vector),
+        )
     }
 
     fn ref_(env: &Env, vector: Tag, index: usize) -> Option<Tag> {
         let image = Vector::to_image(env, vector);
 
-        let len = Fixnum::as_i64(image.length) as usize;
-        if index >= len {
+        if index >= Fixnum::as_i64(image.length) as usize {
             return None;
         }
 
+        let heap_ref = block_on(env.heap.read());
+
+        let vimage = match vector {
+            Tag::Indirect(image) => image,
+            _ => panic!(),
+        };
+
         match Vector::to_type(image.vtype).unwrap() {
-            Type::Byte => match vector {
-                Tag::Indirect(image) => {
-                    let heap_ref = block_on(env.heap.read());
-                    let slice = heap_ref
-                        .image_data_slice(image.image_id() as usize + Self::IMAGE_LEN, index, 1)
-                        .unwrap();
+            Type::Byte => {
+                let slice = heap_ref
+                    .image_data_slice(vimage.image_id() as usize + Self::IMAGE_LEN, index, 1)
+                    .unwrap();
 
-                    Some(Tag::from(slice[0] as i64))
-                }
-                _ => panic!(),
-            },
-            Type::Char => match vector {
-                Tag::Indirect(image) => {
-                    let heap_ref = block_on(env.heap.read());
-                    let slice = heap_ref
-                        .image_data_slice(image.image_id() as usize + Self::IMAGE_LEN, index, 1)
-                        .unwrap();
+                Some(Tag::from(slice[0] as i64))
+            }
+            Type::Char => {
+                let slice = heap_ref
+                    .image_data_slice(vimage.image_id() as usize + Self::IMAGE_LEN, index, 1)
+                    .unwrap();
 
-                    Some(Tag::from(slice[0] as char))
-                }
-                _ => panic!(),
-            },
-            Type::T => match vector {
-                Tag::Indirect(image) => {
-                    let heap_ref = block_on(env.heap.read());
+                Some(Tag::from(slice[0] as char))
+            }
+            Type::T => Some(Tag::from_slice(
+                heap_ref
+                    .image_data_slice(vimage.image_id() as usize + Self::IMAGE_LEN, index * 8, 8)
+                    .unwrap(),
+            )),
+            Type::Fixnum => {
+                let slice = heap_ref
+                    .image_data_slice(vimage.image_id() as usize + Self::IMAGE_LEN, index * 8, 8)
+                    .unwrap();
 
-                    Some(Tag::from_slice(
-                        heap_ref
-                            .image_data_slice(
-                                image.image_id() as usize + Self::IMAGE_LEN,
-                                index * 8,
-                                8,
-                            )
-                            .unwrap(),
-                    ))
-                }
-                _ => panic!(),
-            },
-            Type::Fixnum => match vector {
-                Tag::Indirect(image) => {
-                    let heap_ref = block_on(env.heap.read());
-                    let slice = heap_ref
-                        .image_data_slice(image.image_id() as usize + Self::IMAGE_LEN, index * 8, 8)
-                        .unwrap();
+                Some(Tag::from(i64::from_le_bytes(
+                    slice[0..8].try_into().unwrap(),
+                )))
+            }
+            Type::Float => {
+                let slice = heap_ref
+                    .image_data_slice(vimage.image_id() as usize + Self::IMAGE_LEN, index * 4, 4)
+                    .unwrap();
 
-                    Some(Tag::from(i64::from_le_bytes(
-                        slice[0..8].try_into().unwrap(),
-                    )))
-                }
-                _ => panic!(),
-            },
-            Type::Float => match vector {
-                Tag::Indirect(image) => {
-                    let heap_ref = block_on(env.heap.read());
-                    let slice = heap_ref
-                        .image_data_slice(image.image_id() as usize + Self::IMAGE_LEN, index * 4, 4)
-                        .unwrap();
-
-                    Some(Tag::from(f32::from_le_bytes(
-                        slice[0..4].try_into().unwrap(),
-                    )))
-                }
-                _ => panic!(),
-            },
+                Some(Tag::from(f32::from_le_bytes(
+                    slice[0..4].try_into().unwrap(),
+                )))
+            }
             _ => panic!(),
         }
     }

--- a/src/libcore/types/vector.rs
+++ b/src/libcore/types/vector.rs
@@ -27,10 +27,10 @@ use {
             symbol::{Core as _, Symbol},
         },
     },
+    futures::executor::block_on,
+    futures_locks::RwLock,
     std::{collections::HashMap, str},
 };
-
-use {futures::executor::block_on, futures_locks::RwLock};
 
 pub type VecCacheMap = HashMap<(Type, i32), RwLock<Vec<Tag>>>;
 


### PR DESCRIPTION
make the vector code easier to deal with

docs: no change
tests: no change
regression: no change:
srcs: fix working in lib.rs, remove a lot reducdancy in specialized vector type code
