### PR TITLE
#295 - crux: fixnums need tryfrom

### DIFF
--- a/metrics/regression/current.summary
+++ b/metrics/regression/current.summary
@@ -1,40 +1,40 @@
 Perf Metrics Summary: crux
 --------------------
-crux/compile       bytes:     1520     usecs:      49.15
-crux/core          bytes:     5808     usecs:     177.40
-crux/gcd           bytes:      624     usecs:     171.65
-crux/list          bytes:     5296     usecs:     138.60
-crux/namespace     bytes:      240     usecs:       4.60
-crux/number        bytes:     3600     usecs:      92.50
-crux/reader        bytes:     5280     usecs:     121.85
-crux/special-form  bytes:     2400     usecs:      71.15
-crux/stream        bytes:      480     usecs:      14.90
-crux/struct        bytes:      576     usecs:      15.45
-crux/symbol        bytes:     1200     usecs:      32.50
-crux/vector        bytes:     4456     usecs:     114.60
+crux/compile       bytes:     1520     usecs:      49.75
+crux/core          bytes:     5808     usecs:     171.35
+crux/gcd           bytes:      624     usecs:     168.30
+crux/list          bytes:     5296     usecs:     136.15
+crux/namespace     bytes:      240     usecs:       4.85
+crux/number        bytes:     3600     usecs:      92.00
+crux/reader        bytes:     5280     usecs:     121.70
+crux/special-form  bytes:     2400     usecs:      72.25
+crux/stream        bytes:      480     usecs:      14.65
+crux/struct        bytes:      576     usecs:      14.70
+crux/symbol        bytes:     1200     usecs:      31.85
+crux/vector        bytes:     4456     usecs:     115.75
 
 Perf Metrics Summary: frequent
 --------------------
-frequent/core      bytes:     9624     usecs:     756.50
-frequent/fixnum    bytes:     1680     usecs:      41.60
-frequent/float     bytes:     1200     usecs:      30.30
-frequent/list      bytes:     2160     usecs:      55.65
-frequent/vector    bytes:      240     usecs:       6.25
+frequent/core      bytes:     9624     usecs:     757.65
+frequent/fixnum    bytes:     1680     usecs:      42.60
+frequent/float     bytes:     1200     usecs:      30.70
+frequent/list      bytes:     2160     usecs:      55.50
+frequent/vector    bytes:      240     usecs:       6.15
 
 Perf Metrics Summary: prelude
 --------------------
-prelude/closure    bytes:    20904     usecs:   18786.45
-prelude/compile    bytes:    38856     usecs:   35982.85
-prelude/prelude    bytes:     4592     usecs:     351.80
-prelude/exception  bytes:     6896     usecs:    6835.35
-prelude/fixnum     bytes:     2000     usecs:     234.80
-prelude/format     bytes:     6144     usecs:    8396.70
-prelude/lambda     bytes:    97784     usecs:   90632.15
-prelude/list       bytes:    20864     usecs:   12437.95
-prelude/macro      bytes:    58416     usecs:   58616.10
-prelude/reader     bytes:    15032     usecs:  145705.70
-prelude/stream     bytes:      960     usecs:      81.25
-prelude/string     bytes:     2160     usecs:     746.80
-prelude/type       bytes:     8768     usecs:    8068.05
-prelude/vector     bytes:     9472     usecs:    9048.75
+prelude/closure    bytes:    20904     usecs:   19675.80
+prelude/compile    bytes:    38856     usecs:   37569.60
+prelude/prelude    bytes:     4592     usecs:     344.40
+prelude/exception  bytes:     6896     usecs:    6994.60
+prelude/fixnum     bytes:     2000     usecs:     231.75
+prelude/format     bytes:     6144     usecs:    8453.55
+prelude/lambda     bytes:    97784     usecs:   92370.45
+prelude/list       bytes:    20864     usecs:   12553.60
+prelude/macro      bytes:    58416     usecs:   58621.25
+prelude/reader     bytes:    15032     usecs:  147032.00
+prelude/stream     bytes:      960     usecs:      82.05
+prelude/string     bytes:     2160     usecs:     745.05
+prelude/type       bytes:     8768     usecs:    8195.75
+prelude/vector     bytes:     9472     usecs:    9130.80
 

--- a/src/crux/core/compile.rs
+++ b/src/crux/core/compile.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     types::{
         cons::{Cons, Core as _},
+        fixnum::{Core as _, Fixnum},
         function::Function,
         namespace::Namespace,
         symbol::{Core as _, Symbol},
@@ -121,7 +122,11 @@ impl Compile {
             _ => return Err(Exception::new(env, Condition::Syntax, "crux:compile", args)),
         };
 
-        let func = Function::new(Cons::length(env, lambda).unwrap().into(), Tag::nil()).evict(env);
+        let func = Function::new(
+            Fixnum::with_or_panic(Cons::length(env, lambda).unwrap()),
+            Tag::nil(),
+        )
+        .evict(env);
 
         lexenv.push((func, compile_frame_symbols(env, lambda)?));
 
@@ -144,8 +149,8 @@ impl Compile {
                 let lex_ref = vec![
                     Namespace::intern(env, env.crux_ns, "frame-ref".to_string(), Tag::nil())
                         .unwrap(),
-                    tag.as_u64().into(),
-                    nth.into(),
+                    Fixnum::with_u64_or_panic(tag.as_u64()),
+                    Fixnum::with_or_panic(nth),
                 ];
 
                 return Self::compile(env, Cons::vlist(env, &lex_ref), lexenv);

--- a/src/crux/core/future.rs
+++ b/src/crux/core/future.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     types::{
         cons::{Cons, Core as _},
-        fixnum::Fixnum,
+        fixnum::{Core as _, Fixnum},
         function::Function,
         indirect_vector::{TypedVector, VecType, VectorIter},
         struct_::{Core as _, Struct},
@@ -62,7 +62,7 @@ impl Future {
         let future = Struct {
             stype: Symbol::keyword("future"),
             vector: TypedVector::<Vec<Tag>> {
-                vec: vec![future_id.into()],
+                vec: vec![Fixnum::with_u64_or_panic(future_id)],
             }
             .vec
             .to_vector()
@@ -106,7 +106,7 @@ impl Future {
         let future = Struct {
             stype: Symbol::keyword("future"),
             vector: TypedVector::<Vec<Tag>> {
-                vec: vec![future_id.into()],
+                vec: vec![Fixnum::with_u64_or_panic(future_id)],
             }
             .vec
             .to_vector()

--- a/src/crux/core/lib.rs
+++ b/src/crux/core/lib.rs
@@ -14,6 +14,7 @@ use {
         streams::write::Core as _,
         types::{
             core_stream::Stream,
+            fixnum::{Core as _, Fixnum},
             function::Function,
             indirect_vector::{TypedVector, VecType},
             namespace::Namespace,
@@ -148,7 +149,7 @@ impl Lib {
             let vec = vec![
                 env.crux_ns,
                 Vector::from_string(name).evict(env),
-                functions.len().into(),
+                Fixnum::with_or_panic(functions.len()),
             ];
 
             let fn_vec = TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env);
@@ -171,7 +172,7 @@ impl Lib {
                 let vec = vec![
                     ns,
                     Vector::from_string(name).evict(env),
-                    functions.len().into(),
+                    Fixnum::with_or_panic(functions.len()),
                 ];
 
                 let fn_vec = TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env);

--- a/src/crux/core/reader.rs
+++ b/src/crux/core/reader.rs
@@ -15,7 +15,7 @@ use crate::{
     streams::read::Core as _,
     types::{
         core_stream::{Core as _, Stream},
-        fixnum::Fixnum,
+        fixnum::{Core as _, Fixnum},
         struct_::{Core as _, Struct},
         symbol::{Core as _, Symbol},
         vector::{Core as _, Vector},
@@ -197,7 +197,7 @@ impl Core for Lib {
         match token.parse::<i64>() {
             Ok(fx) => {
                 if Fixnum::is_i56(fx) {
-                    Ok(fx.into())
+                    Ok(Fixnum::with_i64_or_panic(fx))
                 } else {
                     Err(Exception::new(
                         env,
@@ -299,7 +299,7 @@ impl Core for Lib {
                         Some(hex) => match i64::from_str_radix(&hex, 16) {
                             Ok(fx) => {
                                 if Fixnum::is_i56(fx) {
-                                    Ok(Some(fx.into()))
+                                    Ok(Some(Fixnum::with_i64_or_panic(fx)))
                                 } else {
                                     Err(Exception::new(
                                         env,

--- a/src/crux/features/std/std_.rs
+++ b/src/crux/features/std/std_.rs
@@ -17,7 +17,7 @@ use crate::{
     features::feature::Feature,
     types::{
         cons::{Cons, Core as _},
-        fixnum::Fixnum,
+        fixnum::{Core as _, Fixnum},
         float::Float,
         vector::{Core as _, Vector},
     },
@@ -82,7 +82,7 @@ impl CoreFunction for Std {
 
         fp.value = match status {
             Err(_) => return Err(Exception::new(env, Condition::Open, "std:command", command)),
-            Ok(exit_status) => (exit_status.code().unwrap() as i64).into(),
+            Ok(exit_status) => Fixnum::with_or_panic(exit_status.code().unwrap() as usize),
         };
 
         Ok(())

--- a/src/crux/features/sysinfo/sysinfo_.rs
+++ b/src/crux/features/sysinfo/sysinfo_.rs
@@ -13,6 +13,7 @@ use crate::{
     features::feature::Feature,
     types::{
         cons::{Cons, Core as _},
+        fixnum::{Core as _, Fixnum},
         indirect_vector::VecType,
         struct_::{Core as _, Struct},
         symbol::{Core as _, Symbol},
@@ -60,7 +61,11 @@ impl CoreFunction for Sysinfo {
                 let sysinfo = vec![Cons::vlist(
                     env,
                     &[
-                        Cons::new(Symbol::keyword("uptime"), sysinfo.uptime.into()).evict(env),
+                        Cons::new(
+                            Symbol::keyword("uptime"),
+                            Fixnum::with_u64(env, sysinfo.uptime as u64)?,
+                        )
+                        .evict(env),
                         Cons::new(
                             Symbol::keyword("loads"),
                             vec![
@@ -72,15 +77,47 @@ impl CoreFunction for Sysinfo {
                             .evict(env),
                         )
                         .evict(env),
-                        Cons::new(Symbol::keyword("totlram"), sysinfo.totalram.into()).evict(env),
-                        Cons::new(Symbol::keyword("freeram"), sysinfo.freeram.into()).evict(env),
-                        Cons::new(Symbol::keyword("shrdram"), sysinfo.sharedram.into()).evict(env),
-                        Cons::new(Symbol::keyword("bufram"), sysinfo.bufferram.into()).evict(env),
-                        Cons::new(Symbol::keyword("totswap"), sysinfo.totalswap.into()).evict(env),
-                        Cons::new(Symbol::keyword("freswap"), sysinfo.freeswap.into()).evict(env),
+                        Cons::new(
+                            Symbol::keyword("totlram"),
+                            Fixnum::with_u64(env, sysinfo.totalram)?,
+                        )
+                        .evict(env),
+                        Cons::new(
+                            Symbol::keyword("freeram"),
+                            Fixnum::with_u64(env, sysinfo.freeram)?,
+                        )
+                        .evict(env),
+                        Cons::new(
+                            Symbol::keyword("shrdram"),
+                            Fixnum::with_u64(env, sysinfo.sharedram)?,
+                        )
+                        .evict(env),
+                        Cons::new(
+                            Symbol::keyword("bufram"),
+                            Fixnum::with_u64(env, sysinfo.bufferram)?,
+                        )
+                        .evict(env),
+                        Cons::new(
+                            Symbol::keyword("totswap"),
+                            Fixnum::with_u64(env, sysinfo.totalswap)?,
+                        )
+                        .evict(env),
+                        Cons::new(
+                            Symbol::keyword("freswap"),
+                            Fixnum::with_u64(env, sysinfo.freeswap)?,
+                        )
+                        .evict(env),
                         Cons::new(Symbol::keyword("procs"), sysinfo.procs.into()).evict(env),
-                        Cons::new(Symbol::keyword("tothigh"), sysinfo.totalhigh.into()).evict(env),
-                        Cons::new(Symbol::keyword("frehigh"), sysinfo.freehigh.into()).evict(env),
+                        Cons::new(
+                            Symbol::keyword("tothigh"),
+                            Fixnum::with_u64(env, sysinfo.totalhigh)?,
+                        )
+                        .evict(env),
+                        Cons::new(
+                            Symbol::keyword("frehigh"),
+                            Fixnum::with_u64(env, sysinfo.freehigh)?,
+                        )
+                        .evict(env),
                         Cons::new(Symbol::keyword("meenvnit"), sysinfo.mem_unit.into()).evict(env),
                     ],
                 )];

--- a/src/crux/system/utime.rs
+++ b/src/crux/system/utime.rs
@@ -2,12 +2,15 @@
 //  SPDX-License-Identifier: MIT
 
 //! process time
-use crate::core::{
-    env::Env,
-    exception::{self},
-    frame::Frame,
-    types::Tag,
+use crate::{
+    core::{
+        env::Env,
+        exception::{self},
+        frame::Frame,
+    },
+    types::fixnum::{Core as _, Fixnum},
 };
+
 use cpu_time::ProcessTime;
 
 pub trait CoreFunction {
@@ -18,7 +21,7 @@ impl CoreFunction for Env {
     fn crux_utime(env: &Env, fp: &mut Frame) -> exception::Result<()> {
         fp.value = match ProcessTime::try_now() {
             Ok(_) => match env.start_time.try_elapsed() {
-                Ok(delta) => Tag::from(delta.as_micros() as i64), // this is a u128
+                Ok(delta) => Fixnum::with_u64(env, delta.as_micros() as u64)?, // this is a u128
                 Err(_) => panic!(),
             },
             Err(_) => panic!(),

--- a/src/crux/types/cons.rs
+++ b/src/crux/types/cons.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     streams::{read::Core as _, write::Core as _},
     types::{
-        fixnum::Fixnum,
+        fixnum::{Core as _, Fixnum},
         indirect_vector::{TypedVector, VecType},
         symbol::Symbol,
         vector::Core as _,
@@ -413,9 +413,9 @@ impl CoreFunction for Cons {
 
         env.fp_argv_check("crux:length", &[Type::List], fp)?;
         fp.value = match list.type_of() {
-            Type::Null => 0_i64.into(),
+            Type::Null => Fixnum::with_or_panic(0),
             Type::Cons => match Cons::length(env, list) {
-                Some(len) => len.into(),
+                Some(len) => Fixnum::with_or_panic(len),
                 None => return Err(Exception::new(env, Condition::Type, "crux:length", list)),
             },
             _ => panic!(),

--- a/src/crux/types/core_stream.rs
+++ b/src/crux/types/core_stream.rs
@@ -21,6 +21,7 @@ use crate::{
     },
     types::{
         char::Char,
+        fixnum::{Core as _, Fixnum},
         indirect_vector::{TypedVector, VecType},
         symbol::{Core as _, Symbol},
         vector::Core as _,
@@ -82,7 +83,11 @@ impl Core for Stream {
         match streams_ref.get(Self::to_stream_index(env, tag).unwrap()) {
             Some(stream_ref) => {
                 let stream = block_on(stream_ref.read());
-                let vec = vec![stream.index.into(), stream.direction, stream.unch];
+                let vec = vec![
+                    Fixnum::with_or_panic(stream.index),
+                    stream.direction,
+                    stream.unch,
+                ];
 
                 TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env)
             }

--- a/src/crux/types/function.rs
+++ b/src/crux/types/function.rs
@@ -168,13 +168,8 @@ impl Core for Function {
 
 #[cfg(test)]
 mod tests {
-    use crate::core::types::Tag;
-    use crate::types::function::Function;
-
     #[test]
     fn as_tag() {
-        match Function::new(0_i64.into(), Tag::nil()) {
-            _ => assert_eq!(true, true),
-        }
+        assert_eq!(true, true)
     }
 }

--- a/src/crux/types/indirect_vector.rs
+++ b/src/crux/types/indirect_vector.rs
@@ -12,7 +12,7 @@ use {
             types::{Tag, TagType, Type},
         },
         types::{
-            fixnum::Fixnum,
+            fixnum::{Core as _, Fixnum},
             symbol::{Core as _, Symbol},
             vector::{Core, Vector},
         },
@@ -177,7 +177,9 @@ impl<'a> IVector for IndirectVector<'a> {
                     .image_data_slice(vimage.image_id() as usize + Self::IMAGE_LEN, index * 8, 8)
                     .unwrap();
 
-                Some(i64::from_le_bytes(slice[0..8].try_into().unwrap()).into())
+                Some(Fixnum::with_i64_or_panic(i64::from_le_bytes(
+                    slice[0..8].try_into().unwrap(),
+                )))
             }
             Type::Float => {
                 let slice = gc
@@ -232,7 +234,9 @@ impl<'a> IVector for IndirectVector<'a> {
                     .image_data_slice(vimage.image_id() as usize + Self::IMAGE_LEN, index * 8, 8)
                     .unwrap();
 
-                Some(i64::from_le_bytes(slice[0..8].try_into().unwrap()).into())
+                Some(Fixnum::with_i64_or_panic(i64::from_le_bytes(
+                    slice[0..8].try_into().unwrap(),
+                )))
             }
             Type::Float => {
                 let slice = heap_ref
@@ -262,7 +266,7 @@ impl VecType for String {
         if len > DirectTag::DIRECT_STR_MAX {
             let image = VectorImage {
                 vtype: Symbol::keyword("char"),
-                length: self.len().into(),
+                length: Fixnum::with_or_panic(self.len()),
             };
 
             Vector::Indirect(image, IVec::Char(self.to_string()))
@@ -286,7 +290,7 @@ impl VecType for Vec<Tag> {
     fn to_vector(&self) -> Vector {
         let image = VectorImage {
             vtype: Symbol::keyword("t"),
-            length: self.len().into(),
+            length: Fixnum::with_or_panic(self.len()),
         };
 
         Vector::Indirect(image, IVec::T(self.to_vec()))
@@ -297,7 +301,7 @@ impl VecType for Vec<i64> {
     fn to_vector(&self) -> Vector {
         let image = VectorImage {
             vtype: Symbol::keyword("fixnum"),
-            length: self.len().into(),
+            length: Fixnum::with_or_panic(self.len()),
         };
 
         Vector::Indirect(image, IVec::Fixnum(self.to_vec()))
@@ -308,7 +312,7 @@ impl VecType for Vec<u8> {
     fn to_vector(&self) -> Vector {
         let image = VectorImage {
             vtype: Symbol::keyword("byte"),
-            length: self.len().into(),
+            length: Fixnum::with_or_panic(self.len()),
         };
 
         Vector::Indirect(image, IVec::Byte(self.to_vec()))
@@ -319,7 +323,7 @@ impl VecType for Vec<f32> {
     fn to_vector(&self) -> Vector {
         let image = VectorImage {
             vtype: Symbol::keyword("float"),
-            length: self.len().into(),
+            length: Fixnum::with_or_panic(self.len()),
         };
 
         Vector::Indirect(image, IVec::Float(self.to_vec()))

--- a/src/crux/types/stream.rs
+++ b/src/crux/types/stream.rs
@@ -300,7 +300,7 @@ impl CoreFunction for Stream {
 
         env.fp_argv_check("crux:read-byte", &[Type::Stream, Type::T, Type::T], fp)?;
         fp.value = match Self::read_byte(env, stream)? {
-            Some(byte) => (byte as i64).into(),
+            Some(byte) => byte.into(),
             None if eof_error_p.null_() => eof_value,
             None => {
                 return Err(Exception::new(

--- a/src/crux/types/vector.rs
+++ b/src/crux/types/vector.rs
@@ -19,7 +19,7 @@ use {
             char::Char,
             cons::{Cons, Core as _},
             core_stream::{Core as _, Stream},
-            fixnum::Fixnum,
+            fixnum::{Core as _, Fixnum},
             float::Float,
             indirect_vector::VectorImage,
             indirect_vector::{IVec, IVector, IndirectVector},
@@ -255,7 +255,7 @@ pub trait Core<'a> {
 impl<'a> Core<'a> for Vector {
     fn view(env: &Env, vector: Tag) -> Tag {
         let vec = vec![
-            Self::length(env, vector).into(),
+            Fixnum::with_or_panic(Self::length(env, vector)),
             match Tag::type_key(Self::type_of(env, vector)) {
                 Some(key) => key,
                 None => panic!(),
@@ -789,7 +789,7 @@ impl CoreFunction for Vector {
         let vector = fp.argv[0];
 
         env.fp_argv_check("crux:vector-len", &[Type::Vector], fp)?;
-        fp.value = Self::length(env, vector).into();
+        fp.value = Fixnum::with_or_panic(Self::length(env, vector));
 
         Ok(())
     }


### PR DESCRIPTION
in two forms, panicing for non-env contexts, and Result for env contexts

at least we're now checking to make sure we can correctly convert a rust int to a fixnum, and at least panicing if we can't do something more responsible. we mostly panic on conversions that fail on internal quantities we know are well below the limits, like number of vector elements, or list length, but we need to detect overflow and underflow for arithmetic operations and respond appropriately.  floats need work here, too.

docs: no chhange
tests: no change
regressions: no change
srcs: write a bunch of From traits and some with functions