### PR TITLE
#299 - crux: more from/into

### DIFF
--- a/metrics/regression/current.summary
+++ b/metrics/regression/current.summary
@@ -1,40 +1,40 @@
 Perf Metrics Summary: crux
 --------------------
-crux/compile       bytes:     1520     usecs:      49.75
+crux/compile       bytes:     1520     usecs:      48.40
 crux/core          bytes:     5808     usecs:     171.35
-crux/gcd           bytes:      624     usecs:     168.30
-crux/list          bytes:     5296     usecs:     136.15
-crux/namespace     bytes:      240     usecs:       4.85
-crux/number        bytes:     3600     usecs:      92.00
-crux/reader        bytes:     5280     usecs:     121.70
-crux/special-form  bytes:     2400     usecs:      72.25
-crux/stream        bytes:      480     usecs:      14.65
-crux/struct        bytes:      576     usecs:      14.70
-crux/symbol        bytes:     1200     usecs:      31.85
-crux/vector        bytes:     4456     usecs:     115.75
+crux/gcd           bytes:      624     usecs:     164.95
+crux/list          bytes:     5296     usecs:     137.70
+crux/namespace     bytes:      240     usecs:       4.60
+crux/number        bytes:     3600     usecs:      91.80
+crux/reader        bytes:     5280     usecs:     119.75
+crux/special-form  bytes:     2400     usecs:      70.70
+crux/stream        bytes:      480     usecs:      14.90
+crux/struct        bytes:      576     usecs:      15.20
+crux/symbol        bytes:     1200     usecs:      31.15
+crux/vector        bytes:     4456     usecs:     115.15
 
 Perf Metrics Summary: frequent
 --------------------
-frequent/core      bytes:     9624     usecs:     757.65
-frequent/fixnum    bytes:     1680     usecs:      42.60
-frequent/float     bytes:     1200     usecs:      30.70
-frequent/list      bytes:     2160     usecs:      55.50
-frequent/vector    bytes:      240     usecs:       6.15
+frequent/core      bytes:     9624     usecs:     753.85
+frequent/fixnum    bytes:     1680     usecs:      41.80
+frequent/float     bytes:     1200     usecs:      30.25
+frequent/list      bytes:     2160     usecs:      54.75
+frequent/vector    bytes:      240     usecs:       6.35
 
 Perf Metrics Summary: prelude
 --------------------
-prelude/closure    bytes:    20904     usecs:   19675.80
-prelude/compile    bytes:    38856     usecs:   37569.60
-prelude/prelude    bytes:     4592     usecs:     344.40
-prelude/exception  bytes:     6896     usecs:    6994.60
-prelude/fixnum     bytes:     2000     usecs:     231.75
-prelude/format     bytes:     6144     usecs:    8453.55
-prelude/lambda     bytes:    97784     usecs:   92370.45
-prelude/list       bytes:    20864     usecs:   12553.60
-prelude/macro      bytes:    58416     usecs:   58621.25
-prelude/reader     bytes:    15032     usecs:  147032.00
-prelude/stream     bytes:      960     usecs:      82.05
-prelude/string     bytes:     2160     usecs:     745.05
-prelude/type       bytes:     8768     usecs:    8195.75
-prelude/vector     bytes:     9472     usecs:    9130.80
+prelude/closure    bytes:    20904     usecs:   18796.35
+prelude/compile    bytes:    38856     usecs:   36263.90
+prelude/prelude    bytes:     4592     usecs:     353.40
+prelude/exception  bytes:     6896     usecs:    6834.00
+prelude/fixnum     bytes:     2000     usecs:     225.90
+prelude/format     bytes:     6144     usecs:    8554.45
+prelude/lambda     bytes:    97784     usecs:   91187.35
+prelude/list       bytes:    20864     usecs:   12372.45
+prelude/macro      bytes:    58416     usecs:   59706.15
+prelude/reader     bytes:    15032     usecs:  148098.45
+prelude/stream     bytes:      960     usecs:      87.35
+prelude/string     bytes:     2160     usecs:     750.45
+prelude/type       bytes:     8768     usecs:    8024.30
+prelude/vector     bytes:     9472     usecs:    9150.00
 

--- a/src/crux/core/dynamic.rs
+++ b/src/crux/core/dynamic.rs
@@ -16,8 +16,8 @@ use crate::{
     },
     types::{
         cons::{Cons, Core as _},
-        indirect_vector::{TypedVector, VecType},
-        vector::Core as _,
+        indirect_vector::Core as _,
+        vector::Vector,
     },
 };
 
@@ -60,16 +60,12 @@ impl CoreFunction for Env {
 
             Frame::frame_stack_ref(env, (&func.to_le_bytes()).into(), *offset, &mut argv);
 
-            let vec = argv
+            let vec: Vec<Tag> = argv
                 .into_iter()
                 .map(|f| (&f.to_le_bytes()).into())
                 .collect();
 
-            Cons::new(
-                (&func.to_le_bytes()).into(),
-                TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env),
-            )
-            .evict(env)
+            Cons::new((&func.to_le_bytes()).into(), Vector::from(vec).evict(env)).evict(env)
         }));
 
         fp.value = Cons::vlist(env, &frames);

--- a/src/crux/core/env.rs
+++ b/src/crux/core/env.rs
@@ -63,17 +63,17 @@ impl Env {
         };
 
         // establish namespaces
-        env.null_ns = match Namespace::add_ns(&env, "") {
+        env.null_ns = match Namespace::with(&env, "") {
             Ok(ns) => ns,
             Err(_) => panic!(),
         };
 
-        env.keyword_ns = match Namespace::add_static_ns(&env, "keyword", &LIB.keywords) {
+        env.keyword_ns = match Namespace::with_static(&env, "keyword", &LIB.keywords) {
             Ok(ns) => ns,
             Err(_) => panic!(),
         };
 
-        env.crux_ns = match Namespace::add_static_ns(&env, "crux", &LIB.symbols) {
+        env.crux_ns = match Namespace::with_static(&env, "crux", &LIB.symbols) {
             Ok(ns) => ns,
             Err(_) => panic!(),
         };

--- a/src/crux/core/frame.rs
+++ b/src/crux/core/frame.rs
@@ -19,9 +19,9 @@ use crate::{
         cons::{Cons, Core as _},
         fixnum::Fixnum,
         function::Function,
-        indirect_vector::VectorIter,
         struct_::{Core as _, Struct},
         symbol::{Core as _, Symbol},
+        vector::VectorIter,
         vector::{Core as _, Vector},
     },
 };

--- a/src/crux/core/future.rs
+++ b/src/crux/core/future.rs
@@ -17,7 +17,7 @@ use crate::{
         cons::{Cons, Core as _},
         fixnum::{Core as _, Fixnum},
         function::Function,
-        indirect_vector::{TypedVector, VecType, VectorIter},
+        indirect_vector::Core as _,
         struct_::{Core as _, Struct},
         symbol::{Core as _, Symbol},
         vector::{Core as _, Vector},
@@ -61,12 +61,7 @@ impl Future {
 
         let future = Struct {
             stype: Symbol::keyword("future"),
-            vector: TypedVector::<Vec<Tag>> {
-                vec: vec![Fixnum::with_u64_or_panic(future_id)],
-            }
-            .vec
-            .to_vector()
-            .evict(env),
+            vector: Vector::from(vec![Fixnum::with_u64_or_panic(future_id)]).evict(env),
         }
         .evict(env);
 
@@ -105,12 +100,7 @@ impl Future {
 
         let future = Struct {
             stype: Symbol::keyword("future"),
-            vector: TypedVector::<Vec<Tag>> {
-                vec: vec![Fixnum::with_u64_or_panic(future_id)],
-            }
-            .vec
-            .to_vector()
-            .evict(env),
+            vector: Vector::from(vec![Fixnum::with_u64_or_panic(future_id)]).evict(env),
         }
         .evict(env);
 

--- a/src/crux/core/heap.rs
+++ b/src/crux/core/heap.rs
@@ -18,10 +18,10 @@ use crate::{
         cons::{Cons, Core as _},
         fixnum::{Core as _, Fixnum},
         function::{Core as _, Function},
-        indirect_vector::{TypedVector, VecType},
+        indirect_vector::Core as _,
         struct_::{Core as _, Struct},
         symbol::{Core as _, Symbol},
-        vector::{Core as _, Vector},
+        vector::Vector,
     },
 };
 
@@ -106,7 +106,7 @@ impl CoreFunction for Heap {
             ])
         }
 
-        fp.value = TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env);
+        fp.value = Vector::from(vec).evict(env);
 
         Ok(())
     }
@@ -120,7 +120,7 @@ impl CoreFunction for Heap {
             Fixnum::with_or_panic(npages),
         ];
 
-        fp.value = TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env);
+        fp.value = Vector::from(vec).evict(env);
 
         Ok(())
     }

--- a/src/crux/core/reader.rs
+++ b/src/crux/core/reader.rs
@@ -16,6 +16,7 @@ use crate::{
     types::{
         core_stream::{Core as _, Stream},
         fixnum::{Core as _, Fixnum},
+        indirect_vector::Core as _,
         struct_::{Core as _, Struct},
         symbol::{Core as _, Symbol},
         vector::{Core as _, Vector},
@@ -203,7 +204,7 @@ impl Core for Lib {
                         env,
                         Condition::Over,
                         "crux:read",
-                        Vector::from_string(&token).evict(env),
+                        Vector::from(token).evict(env),
                     ))
                 }
             }
@@ -240,7 +241,7 @@ impl Core for Lib {
                                             env,
                                             Condition::Type,
                                             "crux:read",
-                                            Vector::from_string(&phrase).evict(env),
+                                            Vector::from(phrase).evict(env),
                                         )),
                                     }
                                 }
@@ -305,7 +306,7 @@ impl Core for Lib {
                                         env,
                                         Condition::Over,
                                         "crux:read",
-                                        Vector::from_string(&hex).evict(env),
+                                        Vector::from(hex).evict(env),
                                     ))
                                 }
                             }

--- a/src/crux/core/types.rs
+++ b/src/crux/core/types.rs
@@ -21,7 +21,7 @@ use {
             fixnum::{Core as _, Fixnum},
             float::{Core as _, Float},
             function::{Core as _, Function},
-            indirect_vector::{TypedVector, VecType},
+            indirect_vector::Core as _,
             struct_::{Core as _, Struct},
             symbol::{Core as _, Symbol},
             vector::{Core as _, Vector},
@@ -235,16 +235,10 @@ impl CoreFunction for Tag {
         let arg = fp.argv[1];
 
         env.fp_argv_check("crux:repr", &[Type::Keyword, Type::T], fp)?;
-
         fp.value = if type_.eq_(&Symbol::keyword("vector")) {
-            let slice = arg.as_slice();
+            let slice = arg.as_slice().to_vec();
 
-            TypedVector::<Vec<u8>> {
-                vec: slice.to_vec(),
-            }
-            .vec
-            .to_vector()
-            .evict(env)
+            Vector::from(slice).evict(env)
         } else if type_.eq_(&Symbol::keyword("t")) {
             if Vector::type_of(env, arg) == Type::Byte && Vector::length(env, arg) == 8 {
                 let mut u64_: u64 = 0;

--- a/src/crux/features/nix/nix_.rs
+++ b/src/crux/features/nix/nix_.rs
@@ -13,9 +13,10 @@ use crate::{
     features::feature::Feature,
     types::{
         cons::{Cons, Core as _},
+        indirect_vector::Core as _,
         struct_::{Core as _, Struct},
         symbol::{Core as _, Symbol},
-        vector::{Core as _, Vector},
+        vector::Vector,
     },
 };
 use nix::{self};
@@ -61,27 +62,27 @@ impl CoreFunction for Nix {
                     &[
                         Cons::new(
                             Symbol::keyword("sysname"),
-                            Vector::from_string(info.sysname().to_str().unwrap()).evict(env),
+                            Vector::from(info.sysname().to_str().unwrap()).evict(env),
                         )
                         .evict(env),
                         Cons::new(
                             Symbol::keyword("node"),
-                            Vector::from_string(info.nodename().to_str().unwrap()).evict(env),
+                            Vector::from(info.nodename().to_str().unwrap()).evict(env),
                         )
                         .evict(env),
                         Cons::new(
                             Symbol::keyword("release"),
-                            Vector::from_string(info.release().to_str().unwrap()).evict(env),
+                            Vector::from(info.release().to_str().unwrap()).evict(env),
                         )
                         .evict(env),
                         Cons::new(
                             Symbol::keyword("version"),
-                            Vector::from_string(info.version().to_str().unwrap()).evict(env),
+                            Vector::from(info.version().to_str().unwrap()).evict(env),
                         )
                         .evict(env),
                         Cons::new(
                             Symbol::keyword("machine"),
-                            Vector::from_string(info.machine().to_str().unwrap()).evict(env),
+                            Vector::from(info.machine().to_str().unwrap()).evict(env),
                         )
                         .evict(env),
                     ],

--- a/src/crux/features/std/std_.rs
+++ b/src/crux/features/std/std_.rs
@@ -19,6 +19,7 @@ use crate::{
         cons::{Cons, Core as _},
         fixnum::{Core as _, Fixnum},
         float::Float,
+        indirect_vector::Core as _,
         vector::{Core as _, Vector},
     },
 };
@@ -104,11 +105,8 @@ impl CoreFunction for Std {
 
             for (key, value) in std::env::vars() {
                 vars.push(
-                    Cons::new(
-                        Vector::from_string(&key).evict(env),
-                        Vector::from_string(&value).evict(env),
-                    )
-                    .evict(env),
+                    Cons::new(Vector::from(key).evict(env), Vector::from(value).evict(env))
+                        .evict(env),
                 )
             }
 

--- a/src/crux/features/sysinfo/sysinfo_.rs
+++ b/src/crux/features/sysinfo/sysinfo_.rs
@@ -14,10 +14,10 @@ use crate::{
     types::{
         cons::{Cons, Core as _},
         fixnum::{Core as _, Fixnum},
-        indirect_vector::VecType,
+        indirect_vector::Core as _,
         struct_::{Core as _, Struct},
         symbol::{Core as _, Symbol},
-        vector::Core as _,
+        vector::Vector,
     },
 };
 use sysinfo_dot_h::{self};
@@ -68,12 +68,11 @@ impl CoreFunction for Sysinfo {
                         .evict(env),
                         Cons::new(
                             Symbol::keyword("loads"),
-                            vec![
+                            Vector::from(vec![
                                 sysinfo.loads[0] as f32,
                                 sysinfo.loads[1] as f32,
                                 sysinfo.loads[2] as f32,
-                            ]
-                            .to_vector()
+                            ])
                             .evict(env),
                         )
                         .evict(env),

--- a/src/crux/streams/write.rs
+++ b/src/crux/streams/write.rs
@@ -17,10 +17,11 @@ use crate::{
         fixnum::{Core as _, Fixnum},
         float::{Core as _, Float},
         function::{Core as _, Function},
+        indirect_vector::Core as _,
         namespace::{Core as _, Namespace},
         struct_::{Core as _, Struct},
         symbol::{Core as _, Symbol},
-        vector::{Core as _, Vector},
+        vector::Vector,
     },
 };
 

--- a/src/crux/types/char.rs
+++ b/src/crux/types/char.rs
@@ -12,8 +12,8 @@ use crate::{
     streams::write::Core as _,
     types::{
         core_stream::{Core as _, Stream},
-        indirect_vector::{TypedVector, VecType},
-        vector::Core as _,
+        indirect_vector::Core as _,
+        vector::Vector,
     },
 };
 
@@ -67,9 +67,7 @@ impl Core for Char {
     }
 
     fn view(env: &Env, chr: Tag) -> Tag {
-        let vec = vec![chr];
-
-        TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env)
+        Vector::from(vec![chr]).evict(env)
     }
 }
 

--- a/src/crux/types/cons.rs
+++ b/src/crux/types/cons.rs
@@ -17,9 +17,9 @@ use crate::{
     streams::{read::Core as _, write::Core as _},
     types::{
         fixnum::{Core as _, Fixnum},
-        indirect_vector::{TypedVector, VecType},
+        indirect_vector::Core as _,
         symbol::Symbol,
-        vector::Core as _,
+        vector::Vector,
     },
 };
 
@@ -132,7 +132,7 @@ impl Cons {
 
                 Some(n)
             }
-            _ => panic!("cons::length"),
+            _ => panic!(),
         }
     }
 
@@ -177,7 +177,7 @@ impl Core for Cons {
     fn view(env: &Env, cons: Tag) -> Tag {
         let vec = vec![Self::car(env, cons), Self::cdr(env, cons)];
 
-        TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env)
+        Vector::from(vec).evict(env)
     }
 
     fn iter(env: &Env, cons: Tag) -> ConsIter {
@@ -405,6 +405,7 @@ impl CoreFunction for Cons {
 
     fn crux_cons(env: &Env, fp: &mut Frame) -> exception::Result<()> {
         fp.value = Self::new(fp.argv[0], fp.argv[1]).evict(env);
+
         Ok(())
     }
 

--- a/src/crux/types/core_stream.rs
+++ b/src/crux/types/core_stream.rs
@@ -22,9 +22,9 @@ use crate::{
     types::{
         char::Char,
         fixnum::{Core as _, Fixnum},
-        indirect_vector::{TypedVector, VecType},
+        indirect_vector::Core as _,
         symbol::{Core as _, Symbol},
-        vector::Core as _,
+        vector::Vector,
     },
 };
 
@@ -89,7 +89,7 @@ impl Core for Stream {
                     stream.unch,
                 ];
 
-                TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env)
+                Vector::from(vec).evict(env)
             }
             None => panic!(),
         }

--- a/src/crux/types/fixnum.rs
+++ b/src/crux/types/fixnum.rs
@@ -14,9 +14,9 @@ use crate::{
     streams::write::Core as _,
     types::{
         cons::{Cons, Core as _},
-        indirect_vector::{TypedVector, VecType},
+        indirect_vector::Core as _,
         symbol::{Core as _, Symbol},
-        vector::Core as _,
+        vector::Vector,
     },
 };
 
@@ -164,9 +164,7 @@ impl Core for Fixnum {
     }
 
     fn view(env: &Env, fx: Tag) -> Tag {
-        let vec = vec![fx];
-
-        TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env)
+        Vector::from(vec![fx]).evict(env)
     }
 }
 

--- a/src/crux/types/float.rs
+++ b/src/crux/types/float.rs
@@ -14,9 +14,9 @@ use {
         },
         streams::write::Core as _,
         types::{
-            indirect_vector::{TypedVector, VecType},
+            indirect_vector::Core as _,
             symbol::{Core as _, Symbol},
-            vector::Core as _,
+            vector::Vector,
         },
     },
     std::ops::{Add, Div, Mul, Sub},
@@ -63,9 +63,7 @@ pub trait Core {
 
 impl Core for Float {
     fn view(env: &Env, fl: Tag) -> Tag {
-        let vec = vec![fl];
-
-        TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env)
+        Vector::from(vec![fl]).evict(env)
     }
 
     fn write(env: &Env, tag: Tag, _escape: bool, stream: Tag) -> exception::Result<()> {

--- a/src/crux/types/function.rs
+++ b/src/crux/types/function.rs
@@ -13,7 +13,7 @@ use crate::{
     streams::write::Core as _,
     types::{
         fixnum::Fixnum,
-        indirect_vector::{TypedVector, VecType},
+        indirect_vector::Core as _,
         namespace::Namespace,
         vector::{Core as _, Vector},
     },
@@ -122,7 +122,7 @@ impl Core for Function {
     fn view(env: &Env, func: Tag) -> Tag {
         let vec = vec![Self::arity(env, func), Self::form(env, func)];
 
-        TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env)
+        Vector::from(vec).evict(env)
     }
 
     fn heap_size(env: &Env, fn_: Tag) -> usize {
@@ -149,7 +149,7 @@ impl Core for Function {
                         let name = Vector::ref_heap(env, form, 1).unwrap();
 
                         (
-                            Namespace::ns_name(env, ns).unwrap(),
+                            Namespace::name(env, ns).unwrap(),
                             Vector::as_string(env, name).to_string(),
                         )
                     }

--- a/src/crux/types/stream.rs
+++ b/src/crux/types/stream.rs
@@ -20,6 +20,7 @@ use crate::{
         char::Char,
         core_stream::{Core as _, Stream},
         fixnum::Fixnum,
+        indirect_vector::Core as _,
         symbol::{Core as _, Symbol},
         vector::{Core as _, Vector},
     },
@@ -266,7 +267,7 @@ impl CoreFunction for Stream {
         env.fp_argv_check("crux:get-string", &[Type::Stream], fp)?;
 
         let string = Self::get_string(env, stream)?;
-        fp.value = Vector::from_string(&string).evict(env);
+        fp.value = Vector::from(string).evict(env);
 
         Ok(())
     }

--- a/src/crux/types/vector.rs
+++ b/src/crux/types/vector.rs
@@ -6,24 +6,23 @@ use {
     crate::{
         core::{
             apply::Core as _,
-            direct::{DirectInfo, DirectTag, DirectType},
+            direct::DirectType,
             env::Env,
             exception::{self, Condition, Exception},
             frame::Frame,
-            gc::{Gc, HeapGcRef},
+            gc::Gc,
             readtable::{map_char_syntax, SyntaxType},
             types::{Tag, Type},
         },
-        streams::write::Core as _,
         types::{
             char::Char,
             cons::{Cons, Core as _},
             core_stream::{Core as _, Stream},
             fixnum::{Core as _, Fixnum},
             float::Float,
-            indirect_vector::VectorImage,
-            indirect_vector::{IVec, IVector, IndirectVector},
-            indirect_vector::{TypedVector, VecType, VectorIter},
+            indirect_vector::{
+                Core as _, IndirectType, IndirectVector, IndirectVectorType, VectorImage,
+            },
             symbol::{Core as _, Symbol},
         },
     },
@@ -32,21 +31,21 @@ use {
     std::{collections::HashMap, str},
 };
 
-pub type VecCacheMap = HashMap<(Type, i32), RwLock<Vec<Tag>>>;
-
-pub enum Vector {
-    Direct(Tag),
-    Indirect(VectorImage, IVec),
-}
-
 lazy_static! {
-    static ref VTYPEMAP: Vec<(Tag, Type)> = vec![
+    pub static ref VTYPEMAP: Vec<(Tag, Type)> = vec![
         (Symbol::keyword("t"), Type::T),
         (Symbol::keyword("char"), Type::Char),
         (Symbol::keyword("byte"), Type::Byte),
         (Symbol::keyword("fixnum"), Type::Fixnum),
         (Symbol::keyword("float"), Type::Float),
     ];
+}
+
+pub type VecCacheMap = HashMap<(Type, i32), RwLock<Vec<Tag>>>;
+
+pub enum Vector {
+    Direct(Tag),
+    Indirect(VectorImage, IndirectType),
 }
 
 impl Vector {
@@ -58,42 +57,6 @@ impl Vector {
             .copied()
             .find(|tab| keyword.eq_(&tab.0))
             .map(|tab| tab.1)
-    }
-
-    pub fn to_image(env: &Env, tag: Tag) -> VectorImage {
-        let heap_ref = block_on(env.heap.read());
-
-        match tag.type_of() {
-            Type::Vector => match tag {
-                Tag::Indirect(image) => VectorImage {
-                    vtype: Tag::from_slice(
-                        heap_ref.image_slice(image.image_id() as usize).unwrap(),
-                    ),
-                    length: Tag::from_slice(
-                        heap_ref.image_slice(image.image_id() as usize + 1).unwrap(),
-                    ),
-                },
-                _ => panic!(),
-            },
-            _ => panic!(),
-        }
-    }
-
-    pub fn gc_ref_image(heap_ref: &mut HeapGcRef, tag: Tag) -> VectorImage {
-        match tag.type_of() {
-            Type::Vector => match tag {
-                Tag::Indirect(image) => VectorImage {
-                    vtype: Tag::from_slice(
-                        heap_ref.image_slice(image.image_id() as usize).unwrap(),
-                    ),
-                    length: Tag::from_slice(
-                        heap_ref.image_slice(image.image_id() as usize + 1).unwrap(),
-                    ),
-                },
-                _ => panic!(),
-            },
-            _ => panic!(),
-        }
     }
 
     pub fn type_of(env: &Env, vector: Tag) -> Type {
@@ -192,21 +155,21 @@ impl Vector {
                 let tag_vec = block_on(vec_map.read());
 
                 let tag = match ivec {
-                    IVec::Byte(u8_vec) => tag_vec.iter().find(|src| {
+                    IndirectType::Byte(u8_vec) => tag_vec.iter().find(|src| {
                         u8_vec.iter().enumerate().all(|(index, byte)| {
                             *byte as i64
                                 == Fixnum::as_i64(Vector::ref_heap(env, **src, index).unwrap())
                         })
                     }),
-                    IVec::Char(string) => tag_vec
+                    IndirectType::Char(string) => tag_vec
                         .iter()
                         .find(|src| *string == Vector::as_string(env, **src)),
-                    IVec::Fixnum(i64_vec) => tag_vec.iter().find(|src| {
+                    IndirectType::Fixnum(i64_vec) => tag_vec.iter().find(|src| {
                         i64_vec.iter().enumerate().all(|(index, fixnum)| {
                             *fixnum == Fixnum::as_i64(Vector::ref_heap(env, **src, index).unwrap())
                         })
                     }),
-                    IVec::Float(float_vec) => tag_vec.iter().find(|src| {
+                    IndirectType::Float(float_vec) => tag_vec.iter().find(|src| {
                         float_vec.iter().enumerate().all(|(index, float)| {
                             *float
                                 == Float::as_f32(env, Vector::ref_heap(env, **src, index).unwrap())
@@ -242,14 +205,10 @@ impl Vector {
 // core
 pub trait Core<'a> {
     fn as_string(_: &Env, _: Tag) -> String;
-    fn evict(&self, _: &Env) -> Tag;
-    fn from_string(_: &str) -> Vector;
-    fn heap_size(_: &Env, _: Tag) -> usize;
+    fn gc_ref(_: &mut Gc, _: &Env, _: Tag, _: usize) -> Option<Tag>;
     fn read(_: &Env, _: char, _: Tag) -> exception::Result<Tag>;
     fn ref_heap(_: &Env, _: Tag, _: usize) -> Option<Tag>;
-    fn gc_ref(_: &mut Gc, _: &Env, _: Tag, _: usize) -> Option<Tag>;
     fn view(_: &Env, _: Tag) -> Tag;
-    fn write(_: &Env, _: Tag, _: bool, _: Tag) -> exception::Result<()>;
 }
 
 impl<'a> Core<'a> for Vector {
@@ -262,47 +221,7 @@ impl<'a> Core<'a> for Vector {
             },
         ];
 
-        TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env)
-    }
-
-    fn heap_size(env: &Env, vector: Tag) -> usize {
-        match vector {
-            Tag::Direct(_) => std::mem::size_of::<DirectTag>(),
-            Tag::Indirect(_) => {
-                let len = Self::length(env, vector);
-                let size = match Self::type_of(env, vector) {
-                    Type::Byte | Type::Char => 1,
-                    Type::Fixnum | Type::Float | Type::T => 8,
-                    _ => panic!(),
-                };
-
-                std::mem::size_of::<VectorImage>() + (size * len)
-            }
-        }
-    }
-
-    fn from_string(str: &str) -> Vector {
-        let len = str.len();
-
-        if len > DirectTag::DIRECT_STR_MAX {
-            TypedVector::<String> {
-                vec: str.to_string(),
-            }
-            .vec
-            .to_vector()
-        } else {
-            let mut data: [u8; 8] = 0_u64.to_le_bytes();
-
-            for (src, dst) in str.as_bytes().iter().zip(data.iter_mut()) {
-                *dst = *src
-            }
-
-            Vector::Direct(DirectTag::to_direct(
-                u64::from_le_bytes(data),
-                DirectInfo::Length(len),
-                DirectType::ByteVector,
-            ))
-        }
+        Vector::from(vec).evict(env)
     }
 
     fn as_string(env: &Env, tag: Tag) -> String {
@@ -332,254 +251,6 @@ impl<'a> Core<'a> for Vector {
                 }
             },
             _ => panic!(),
-        }
-    }
-
-    fn write(env: &Env, vector: Tag, escape: bool, stream: Tag) -> exception::Result<()> {
-        match vector {
-            Tag::Direct(_) => match str::from_utf8(&vector.data(env).to_le_bytes()) {
-                Ok(s) => {
-                    if escape {
-                        env.write_string("\"", stream).unwrap()
-                    }
-
-                    for nth in 0..DirectTag::length(vector) {
-                        Stream::write_char(env, stream, s.as_bytes()[nth] as char)?;
-                    }
-
-                    if escape {
-                        env.write_string("\"", stream).unwrap()
-                    }
-
-                    Ok(())
-                }
-                Err(_) => panic!(),
-            },
-            Tag::Indirect(_) => match Self::type_of(env, vector) {
-                Type::Char => {
-                    if escape {
-                        env.write_string("\"", stream)?;
-                    }
-
-                    for ch in VectorIter::new(env, vector) {
-                        env.write_stream(ch, false, stream)?;
-                    }
-
-                    if escape {
-                        env.write_string("\"", stream)?;
-                    }
-
-                    Ok(())
-                }
-                _ => {
-                    env.write_string("#(", stream)?;
-                    env.write_stream(Self::to_image(env, vector).vtype, true, stream)?;
-
-                    for tag in VectorIter::new(env, vector) {
-                        env.write_string(" ", stream)?;
-                        env.write_stream(tag, false, stream)?;
-                    }
-
-                    env.write_string(")", stream)
-                }
-            },
-        }
-    }
-
-    fn read(env: &Env, syntax: char, stream: Tag) -> exception::Result<Tag> {
-        match syntax {
-            '"' => {
-                let mut str: String = String::new();
-
-                loop {
-                    match Stream::read_char(env, stream)? {
-                        Some('"') => break,
-                        Some(ch) => match map_char_syntax(ch).unwrap() {
-                            SyntaxType::Escape => match Stream::read_char(env, stream)? {
-                                Some(ch) => str.push(ch),
-                                None => {
-                                    return Err(Exception::new(
-                                        env,
-                                        Condition::Eof,
-                                        "crux:read",
-                                        stream,
-                                    ));
-                                }
-                            },
-                            _ => str.push(ch),
-                        },
-                        None => {
-                            return Err(Exception::new(env, Condition::Eof, "crux:read", stream));
-                        }
-                    }
-                }
-
-                Ok(Self::from_string(&str).evict(env))
-            }
-            '(' => {
-                let vec_list = match Cons::read(env, stream) {
-                    Ok(list) => {
-                        if list.null_() {
-                            return Err(Exception::new(
-                                env,
-                                Condition::Type,
-                                "crux:read",
-                                Tag::nil(),
-                            ));
-                        }
-                        list
-                    }
-                    Err(_) => {
-                        return Err(Exception::new(env, Condition::Syntax, "crux:read", stream));
-                    }
-                };
-
-                let vec_type = Cons::car(env, vec_list);
-
-                match VTYPEMAP.iter().copied().find(|tab| vec_type.eq_(&tab.0)) {
-                    Some(tab) => match tab.1 {
-                        Type::T => {
-                            let vec = Cons::iter(env, Cons::cdr(env, vec_list))
-                                .map(|cons| Cons::car(env, cons))
-                                .collect::<Vec<Tag>>();
-                            Ok(TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env))
-                        }
-                        Type::Char => {
-                            let vec: exception::Result<String> =
-                                Cons::iter(env, Cons::cdr(env, vec_list))
-                                    .map(|cons| {
-                                        let ch = Cons::car(env, cons);
-                                        if ch.type_of() == Type::Char {
-                                            Ok(Char::as_char(env, ch))
-                                        } else {
-                                            Err(Exception::new(
-                                                env,
-                                                Condition::Type,
-                                                "crux:read",
-                                                ch,
-                                            ))
-                                        }
-                                    })
-                                    .collect();
-
-                            Ok(TypedVector::<String> { vec: vec? }
-                                .vec
-                                .to_vector()
-                                .evict(env))
-                        }
-                        Type::Byte => {
-                            let vec: exception::Result<Vec<u8>> =
-                                Cons::iter(env, Cons::cdr(env, vec_list))
-                                    .map(|cons| {
-                                        let fx = Cons::car(env, cons);
-                                        if fx.type_of() == Type::Fixnum {
-                                            let byte = Fixnum::as_i64(fx);
-                                            if !(0..255).contains(&byte) {
-                                                Err(Exception::new(
-                                                    env,
-                                                    Condition::Range,
-                                                    "crux:read",
-                                                    fx,
-                                                ))
-                                            } else {
-                                                Ok(byte as u8)
-                                            }
-                                        } else {
-                                            Err(Exception::new(
-                                                env,
-                                                Condition::Type,
-                                                "crux:read",
-                                                fx,
-                                            ))
-                                        }
-                                    })
-                                    .collect();
-
-                            Ok(TypedVector::<Vec<u8>> { vec: vec? }
-                                .vec
-                                .to_vector()
-                                .evict(env))
-                        }
-                        Type::Fixnum => {
-                            let vec: exception::Result<Vec<i64>> =
-                                Cons::iter(env, Cons::cdr(env, vec_list))
-                                    .map(|cons| {
-                                        let fx = Cons::car(env, cons);
-                                        if fx.type_of() == Type::Fixnum {
-                                            Ok(Fixnum::as_i64(fx))
-                                        } else {
-                                            Err(Exception::new(
-                                                env,
-                                                Condition::Type,
-                                                "crux:read",
-                                                fx,
-                                            ))
-                                        }
-                                    })
-                                    .collect();
-
-                            Ok(TypedVector::<Vec<i64>> { vec: vec? }
-                                .vec
-                                .to_vector()
-                                .evict(env))
-                        }
-                        Type::Float => {
-                            let vec: exception::Result<Vec<f32>> =
-                                Cons::iter(env, Cons::cdr(env, vec_list))
-                                    .map(|cons| {
-                                        let fl = Cons::car(env, cons);
-                                        if fl.type_of() == Type::Float {
-                                            Ok(Float::as_f32(env, fl))
-                                        } else {
-                                            Err(Exception::new(
-                                                env,
-                                                Condition::Type,
-                                                "crux:read",
-                                                fl,
-                                            ))
-                                        }
-                                    })
-                                    .collect();
-
-                            Ok(TypedVector::<Vec<f32>> { vec: vec? }
-                                .vec
-                                .to_vector()
-                                .evict(env))
-                        }
-                        _ => panic!(),
-                    },
-                    None => Err(Exception::new(env, Condition::Type, "crux:read", vec_type)),
-                }
-            }
-            _ => panic!(),
-        }
-    }
-
-    fn evict(&self, env: &Env) -> Tag {
-        match self {
-            Vector::Direct(tag) => *tag,
-            Vector::Indirect(image, ivec) => {
-                let indirect = match ivec {
-                    IVec::T(_) => IndirectVector::T(image, ivec),
-                    IVec::Char(_) => IndirectVector::Char(image, ivec),
-                    IVec::Byte(_) => IndirectVector::Byte(image, ivec),
-                    IVec::Fixnum(_) => IndirectVector::Fixnum(image, ivec),
-                    IVec::Float(_) => IndirectVector::Float(image, ivec),
-                };
-
-                match ivec {
-                    IVec::T(_) => indirect.evict(env),
-                    _ => match Self::cached(env, &indirect) {
-                        Some(tag) => tag,
-                        None => {
-                            let tag = indirect.evict(env);
-
-                            Self::cache(env, tag);
-                            tag
-                        }
-                    },
-                }
-            }
         }
     }
 
@@ -614,6 +285,164 @@ impl<'a> Core<'a> for Vector {
             }
         }
     }
+
+    fn read(env: &Env, syntax: char, stream: Tag) -> exception::Result<Tag> {
+        match syntax {
+            '"' => {
+                let mut str: String = String::new();
+
+                loop {
+                    match Stream::read_char(env, stream)? {
+                        Some('"') => break,
+                        Some(ch) => match map_char_syntax(ch).unwrap() {
+                            SyntaxType::Escape => match Stream::read_char(env, stream)? {
+                                Some(ch) => str.push(ch),
+                                None => {
+                                    return Err(Exception::new(
+                                        env,
+                                        Condition::Eof,
+                                        "crux:read",
+                                        stream,
+                                    ));
+                                }
+                            },
+                            _ => str.push(ch),
+                        },
+                        None => {
+                            return Err(Exception::new(env, Condition::Eof, "crux:read", stream));
+                        }
+                    }
+                }
+
+                Ok(Self::from(str).evict(env))
+            }
+            '(' => {
+                let vec_list = match Cons::read(env, stream) {
+                    Ok(list) => {
+                        if list.null_() {
+                            return Err(Exception::new(
+                                env,
+                                Condition::Type,
+                                "crux:read",
+                                Tag::nil(),
+                            ));
+                        }
+                        list
+                    }
+                    Err(_) => {
+                        return Err(Exception::new(env, Condition::Syntax, "crux:read", stream));
+                    }
+                };
+
+                let vec_type = Cons::car(env, vec_list);
+
+                match VTYPEMAP.iter().copied().find(|tab| vec_type.eq_(&tab.0)) {
+                    Some(tab) => match tab.1 {
+                        Type::T => {
+                            let vec = Cons::iter(env, Cons::cdr(env, vec_list))
+                                .map(|cons| Cons::car(env, cons))
+                                .collect::<Vec<Tag>>();
+
+                            Ok(Vector::from(vec).evict(env))
+                        }
+                        Type::Char => {
+                            let vec: exception::Result<String> =
+                                Cons::iter(env, Cons::cdr(env, vec_list))
+                                    .map(|cons| {
+                                        let ch = Cons::car(env, cons);
+                                        if ch.type_of() == Type::Char {
+                                            Ok(Char::as_char(env, ch))
+                                        } else {
+                                            Err(Exception::new(
+                                                env,
+                                                Condition::Type,
+                                                "crux:read",
+                                                ch,
+                                            ))
+                                        }
+                                    })
+                                    .collect();
+
+                            Ok(Vector::from(vec?).evict(env))
+                        }
+                        Type::Byte => {
+                            let vec: exception::Result<Vec<u8>> =
+                                Cons::iter(env, Cons::cdr(env, vec_list))
+                                    .map(|cons| {
+                                        let fx = Cons::car(env, cons);
+                                        if fx.type_of() == Type::Fixnum {
+                                            let byte = Fixnum::as_i64(fx);
+                                            if !(0..255).contains(&byte) {
+                                                Err(Exception::new(
+                                                    env,
+                                                    Condition::Range,
+                                                    "crux:read",
+                                                    fx,
+                                                ))
+                                            } else {
+                                                Ok(byte as u8)
+                                            }
+                                        } else {
+                                            Err(Exception::new(
+                                                env,
+                                                Condition::Type,
+                                                "crux:read",
+                                                fx,
+                                            ))
+                                        }
+                                    })
+                                    .collect();
+
+                            Ok(Vector::from(vec?).evict(env))
+                        }
+                        Type::Fixnum => {
+                            let vec: exception::Result<Vec<i64>> =
+                                Cons::iter(env, Cons::cdr(env, vec_list))
+                                    .map(|cons| {
+                                        let fx = Cons::car(env, cons);
+                                        if fx.type_of() == Type::Fixnum {
+                                            Ok(Fixnum::as_i64(fx))
+                                        } else {
+                                            Err(Exception::new(
+                                                env,
+                                                Condition::Type,
+                                                "crux:read",
+                                                fx,
+                                            ))
+                                        }
+                                    })
+                                    .collect();
+
+                            Ok(Vector::from(vec?).evict(env))
+                        }
+                        Type::Float => {
+                            let vec: exception::Result<Vec<f32>> =
+                                Cons::iter(env, Cons::cdr(env, vec_list))
+                                    .map(|cons| {
+                                        let fl = Cons::car(env, cons);
+                                        if fl.type_of() == Type::Float {
+                                            Ok(Float::as_f32(env, fl))
+                                        } else {
+                                            Err(Exception::new(
+                                                env,
+                                                Condition::Type,
+                                                "crux:read",
+                                                fl,
+                                            ))
+                                        }
+                                    })
+                                    .collect();
+
+                            Ok(Vector::from(vec?).evict(env))
+                        }
+                        _ => panic!(),
+                    },
+                    None => Err(Exception::new(env, Condition::Type, "crux:read", vec_type)),
+                }
+            }
+            _ => panic!(),
+        }
+    }
 }
 
 // env functions
@@ -646,7 +475,7 @@ impl CoreFunction for Vector {
                         .map(|cons| Cons::car(env, cons))
                         .collect::<Vec<Tag>>();
 
-                    TypedVector::<Vec<Tag>> { vec }.vec.to_vector().evict(env)
+                    Vector::from(vec).evict(env)
                 }
                 Type::Char => {
                     let vec: exception::Result<String> = Cons::iter(env, list)
@@ -660,10 +489,7 @@ impl CoreFunction for Vector {
                         })
                         .collect();
 
-                    TypedVector::<String> { vec: vec? }
-                        .vec
-                        .to_vector()
-                        .evict(env)
+                    Vector::from(vec?).evict(env)
                 }
                 Type::Byte => {
                     let vec: exception::Result<Vec<u8>> = Cons::iter(env, list)
@@ -687,10 +513,7 @@ impl CoreFunction for Vector {
                         })
                         .collect();
 
-                    TypedVector::<Vec<u8>> { vec: vec? }
-                        .vec
-                        .to_vector()
-                        .evict(env)
+                    Vector::from(vec?).evict(env)
                 }
                 Type::Fixnum => {
                     let vec: exception::Result<Vec<i64>> = Cons::iter(env, list)
@@ -704,10 +527,7 @@ impl CoreFunction for Vector {
                         })
                         .collect();
 
-                    TypedVector::<Vec<i64>> { vec: vec? }
-                        .vec
-                        .to_vector()
-                        .evict(env)
+                    Vector::from(vec?).evict(env)
                 }
                 Type::Float => {
                     let vec: exception::Result<Vec<f32>> = Cons::iter(env, list)
@@ -721,10 +541,7 @@ impl CoreFunction for Vector {
                         })
                         .collect();
 
-                    TypedVector::<Vec<f32>> { vec: vec? }
-                        .vec
-                        .to_vector()
-                        .evict(env)
+                    Vector::from(vec?).evict(env)
                 }
                 _ => {
                     return Err(Exception::new(
@@ -792,6 +609,34 @@ impl CoreFunction for Vector {
         fp.value = Fixnum::with_or_panic(Self::length(env, vector));
 
         Ok(())
+    }
+}
+
+// iterator
+pub struct VectorIter<'a> {
+    env: &'a Env,
+    pub vec: Tag,
+    pub index: usize,
+}
+
+impl<'a> VectorIter<'a> {
+    pub fn new(env: &'a Env, vec: Tag) -> Self {
+        Self { env, vec, index: 0 }
+    }
+}
+
+impl<'a> Iterator for VectorIter<'a> {
+    type Item = Tag;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= Vector::length(self.env, self.vec) {
+            None
+        } else {
+            let el = Vector::ref_heap(self.env, self.vec, self.index);
+            self.index += 1;
+
+            Some(el.unwrap())
+        }
     }
 }
 


### PR DESCRIPTION
clean up vector allocation and eviction, work on interfaces

docs: no change
tests: no change
regressions: no change
srcs: reorganize indirect vector support, convert a lot of vector intos into froms