### PR TITLE
#387 - mu: add devop tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default = [ "std", "sysinfo", "nix", "ffi" ]
 nix = []
 std = []
 ffi = []
+perf = []
 sysinfo = []  # not for macos
 
 [profile.dev]
@@ -28,6 +29,9 @@ opt-level = 0
 opt-level = 3
 lto = "fat"
 codegen-units = 1
+
+[profile.perf]
+inherits = "release"
 
 [dependencies]
 async-std = "1.12.0"

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ help:
 	@echo "--- build options"
 	@echo "    debug - build runtime for debug and package for distribution"
 	@echo "    release - build runtime for release and package for distribution"
+	@echo "    perf - build runtime for performance monitoring and package for distribution"
 	@echo "--- distribution options"
 	@echo "    doc - generate documentation"
 	@echo "    dist - build distribution image"
@@ -62,6 +63,16 @@ debug:
 	@cp target/release/mu-server dist
 	@cp target/release/mu-sys dist
 	@cp target/release/sysgen dist
+	@make dist --no-print-directory
+
+perf:
+	@cargo build --profile perf --features perf --workspace
+	@cp target/perf/devop dist
+	@cp target/perf/mu-exec dist
+	@cp target/perf/mu-ld dist
+	@cp target/perf/mu-server dist
+	@cp target/perf/mu-sys dist
+	@cp target/perf/sysgen dist
 	@make dist --no-print-directory
 
 dist:

--- a/src/mu/core/mod.rs
+++ b/src/mu/core/mod.rs
@@ -15,6 +15,8 @@ pub mod gc;
 pub mod heap;
 pub mod indirect;
 pub mod lib;
+#[cfg(feature = "perf")]
+pub mod perf;
 pub mod quasi;
 pub mod reader;
 pub mod readtable;

--- a/src/mu/core/perf.rs
+++ b/src/mu/core/perf.rs
@@ -1,0 +1,29 @@
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-License-Identifier: MIT
+
+//! perf
+// #![allow(unused_braces)]
+// #![allow(clippy::identity_op)]
+use crate::core::{
+    env::Env,
+    exception::{self},
+    types::Tag,
+};
+
+pub trait Core {
+    fn event(&self, _: &str, _: &Vec<Tag>) -> exception::Result<()>;
+}
+
+impl Core for Env {
+    fn event(&self, _label: &str, _argv: &Vec<Tag>) -> exception::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn perf() {
+        assert_eq!(2 + 2, 4);
+    }
+}


### PR DESCRIPTION
add perf module and compilation target

docs: no changer
tests: no change
regression: no change
srcs: add perf modules to mu, add perf compilation target to Cargo.toml