### PR TITLE
#374 - prelude: review compilation strategy

### DIFF
--- a/src/prelude/core/compile.l
+++ b/src/prelude/core/compile.l
@@ -61,7 +61,6 @@
 
 (mu:intern prelude "%compile-if"
    (:lambda (form env)
-     ;;; (prelude:warn form "compile-if")
      ((:lambda (length)
           (:if (prelude:%orf (mu:eq length 3) (mu:eq length 4))
                ((:lambda (test t-arm f-arm)
@@ -89,29 +88,40 @@
 ;;;
 (mu:intern prelude "%compile"
    (:lambda (form env)
-      (:if (prelude:consp form)
-           ((:lambda (function-form arg-list)
-               (:if (prelude:keywordp function-form)
-                    (mu:compile form)                    ; mu special form (:key ...)
-                    (:if (mu:eq :symbol (mu:type-of function-form)) ; special form or macro
-                         ((:lambda (special)
-                             (:if special
-                                  (mu:apply (mu:symbol-value special) `(,form ,env))
-                                  ((:lambda (macro-function)
-                                      (:if macro-function
-                                           (prelude:%compile-macro-call function-form arg-list env)
-                                           (prelude:%compile-funcall function-form arg-list env)))
-                                   (prelude:macro-function function-form env))))
-                          (mu:cdr (prelude:%assq
-                                   function-form
-                                   '((define-macro . prelude:%compile-defmacro)
-                                     (if           . prelude:%compile-if)
-                                     (%quasi%      . prelude:%compile-quasi)
-                                     (lambda       . prelude:%compile-lambda)))))
-                    (prelude:%compile-funcall function-form arg-list env))))
-            (mu:car form)
-            (mu:cdr form))
-           form)))
+     (:if (prelude:symbolp form)
+          ((:lambda (ns name)
+             (:if (mu:eq ns (mu:find-namespace ""))
+                  ((:lambda (frame-ref)
+                     ;;; (prelude:warn name "%compiling an unqualified symbol")
+                     ;;; (prelude:warn env "in this environment")
+                     form)
+                   (prelude:%frame-ref form env))
+                  form))
+             (prelude:symbol-namespace form)
+             (prelude:symbol-name form))
+          (:if (prelude:consp form)
+               ((:lambda (function-form arg-list)
+                  (:if (prelude:keywordp function-form)
+                       (mu:compile form)              ; mu special form (:key ...)
+                       (:if (mu:eq :symbol (mu:type-of function-form)) ; special form or macro
+                            ((:lambda (special)
+                               (:if special
+                                    (mu:apply (mu:symbol-value special) `(,form ,env))
+                                    ((:lambda (macro-function)
+                                       (:if macro-function
+                                            (prelude:%compile-macro-call function-form arg-list env)
+                                            (prelude:%compile-funcall function-form arg-list env)))
+                                     (prelude:macro-function function-form env))))
+                             (mu:cdr (prelude:%assq
+                                      function-form
+                                      '((define-macro . prelude:%compile-defmacro)
+                                        (if           . prelude:%compile-if)
+                                        (%quasi%      . prelude:%compile-quasi)
+                                        (lambda       . prelude:%compile-lambda)))))
+                            (prelude:%compile-funcall function-form arg-list env))))
+                (mu:car form)
+                (mu:cdr form))
+           form))))
 
 ;;;
 ;;; prelude's compile interface, compiles in the null environment

--- a/src/prelude/core/environment.l
+++ b/src/prelude/core/environment.l
@@ -14,7 +14,7 @@
    (:lambda (bindings)
      (:if (prelude:listp bindings)
           ((:lambda (env)
-             (prelude:warn env "make-environment: env")
+             ;;; (prelude:warn env "make-environment: env")
              (prelude:mapc
               (:lambda (pair)
                 ((:lambda (symbol value)

--- a/src/prelude/core/exception.l
+++ b/src/prelude/core/exception.l
@@ -60,7 +60,7 @@
                                            value
                                            source
                                            "mu:raise"
-                                           (mu:frames))))))
+                                           (mu:dynamic-env))))))
       (:lambda () (prelude:apply thunk ())))))
 
 (mu:intern prelude "make-exception"
@@ -85,7 +85,7 @@
 (mu:intern prelude "raise-env"
    (:lambda (value source reason)
      (mu:raise
-      (prelude:make-exception :error value source reason (mu:frames))
+      (prelude:make-exception :error value source reason (mu:dynamic-env))
       :except)))
 
 (mu:intern prelude "raise"
@@ -102,6 +102,11 @@
      (mu:write message () mu:*error-output*)
      (mu:write-char #\linefeed mu:*error-output*)
      value))
+
+(mu:intern prelude "eprint"
+   (:lambda (value message)          
+     (prelude:format mu:*error-output* ";;; ~A:~T ~A~%" `(,message ,value))
+    value))
 
 (mu:intern prelude "warn"
    (:lambda (value message)

--- a/src/prelude/core/funcall.l
+++ b/src/prelude/core/funcall.l
@@ -9,7 +9,7 @@
 ;;; argument lists
 ;;;
 (mu:intern prelude "%arg-list"
-    (:lambda (arg-list)
+   (:lambda (arg-list)
       (prelude:foldr
        (:lambda (elt acc)
          `(mu:cons ,elt ,acc))
@@ -17,18 +17,20 @@
        arg-list)))
 
 (mu:intern prelude "%lambda-arg-list"
-    (:lambda (function arg-list)
+   (:lambda (function arg-list)
       (:if (prelude:%prelude-function-p function)
-                ((:lambda (rest nreqs)
-                   (:if (prelude:%andf rest (prelude:zerop nreqs))
-                        `(mu:cons ,(prelude:%arg-list arg-list) ())
-                        ((:lambda (reqs rest)
-                           (prelude:%arg-list `(,@reqs ,(prelude:%arg-list rest))))
-                         (prelude:dropr arg-list (mu:difference (mu:length arg-list) nreqs))
-                         (prelude:dropl arg-list nreqs))))
-                 (prelude:%fn-prop :rest function)
-                 (prelude:%fn-prop :arity function))
-                (prelude:%arg-list arg-list))))
+           ((:lambda (rest nreqs)
+              (:if (prelude:%andf rest (prelude:zerop nreqs))
+                   `(mu:cons ,(prelude:%arg-list arg-list) ())
+                   ((:lambda (reqs rest)
+                      (:if (prelude:%andf (prelude:null rest) (prelude:null reqs))
+                           ()
+                           (prelude:%arg-list `(,@reqs ,(prelude:%arg-list rest)))))
+                    (prelude:dropr arg-list (mu:difference (mu:length arg-list) nreqs))
+                    (prelude:dropl arg-list nreqs))))
+            (prelude:%fn-prop :rest function)
+            (prelude:%fn-prop :arity function))
+           (prelude:%arg-list arg-list))))
 
 (mu:intern prelude "%quoted-lambda-arg-list"
   (:lambda (fn args)
@@ -72,9 +74,7 @@
 ;;;
 (mu:intern prelude "%compile-lambda-call"
    (:lambda (lambda-form arg-list env)
-;;;     (prelude:warn lambda-form "compile-lambda-call")
      ((:lambda (compiled-function)
-        ;;; (prelude:warn compiled-function "compiled-function")
         (:if (prelude:functionp compiled-function)
              (:if (prelude:%prelude-function-p compiled-function)
                   `(,prelude:%fn-apply-quoted ,compiled-function ,(prelude:%compile-lambda-arg-list compiled-function arg-list env))
@@ -84,7 +84,6 @@
 
 (mu:intern prelude "%compile-symbol-call"
    (:lambda (function-symbol arg-list env)
-;;;     (prelude:warn function-symbol "compile-symbol-call")
       (:if (prelude:boundp function-symbol)
            ((:lambda (function)
                (:if (prelude:functionp function)
@@ -97,7 +96,6 @@
 
 (mu:intern prelude "%compile-funcall"
    (:lambda (function-form arg-list env)
-      ;;; (prelude:warn function-form "compile-funcall")
       (:if (prelude:consp function-form)
            (prelude:%compile-lambda-call function-form arg-list env)
            (:if (mu:eq :symbol (mu:type-of function-form))
@@ -106,11 +104,27 @@
 
 ;;;
 ;;; apply closure to argument list
-;;;
+;;; sic transit
+(mu:intern prelude "%describe-fn"
+   (:lambda (fn)
+     (:if (prelude:%prelude-function-p fn)
+          ((:lambda (lambda arity fn env)
+             (prelude:eprint "" "%describe-fn:prelude")
+             (prelude:eprint lambda "    lambda")
+             (prelude:eprint arity "    arity")
+             (prelude:eprint fn "    fn")
+             (prelude:eprint env "    env"))
+           (prelude:%fn-prop :lambda fn)
+           (prelude:%fn-prop :arity fn)
+           (prelude:%fn-prop :fn fn)
+           (prelude:%fn-prop :env fn))
+          (prelude:eprint (mu:view fn) "%describe-fn:mu-fn"))))
+
 (mu:intern prelude "%fn-apply"
    (:lambda (fn arg-list)
-      ;;; (prelude:warn `(,fn ,arg-list) "%fn-apply")
-      ((:lambda (env)
+     ;;; (prelude:%describe-fn fn)
+     ;;; (prelude:eprint arg-list "%fn-apply-quoted:arg list")
+     ((:lambda (env)
         (prelude:%mapc mu:frame-push env)
          ((:lambda (value)
             (prelude:%mapc (:lambda (frame) (mu:frame-pop (mu:car frame))) env)
@@ -122,7 +136,8 @@
 
 (mu:intern prelude "%fn-apply-quoted"
    (:lambda (fn arg-list)
-      ;;; (prelude:warn `(,fn ,arg-list) "%fn-apply-quoted")
+     ;;; (prelude:%describe-fn fn)
+     ;;; (prelude:eprint arg-list "%fn-apply-quoted:arg list")
       ((:lambda (env)
         (prelude:%mapc mu:frame-push env)
         ((:lambda (value)

--- a/src/prelude/core/lambda.l
+++ b/src/prelude/core/lambda.l
@@ -98,7 +98,6 @@
                 body))
           `(,lambda-desc ,@env)))))
 
-#|
 ;;;
 ;;; resolving body symbols
 ;;;
@@ -109,7 +108,7 @@
 ;;; `symbol:` symbol to be compiled
 ;;; `env:` lexical compiled environment
 ;;;
-;;; `returns:` *frame-ref* or *nil*
+;;; `returns:` compiled *frame-ref* or *nil*
 ;;;
 (mu:intern prelude "%frame-ref"
   (:lambda (symbol env)
@@ -128,5 +127,4 @@
              (:lambda (el) (mu:eq el symbol))
              (mu:cdr (prelude:%type-ref :bound frame))))))
      ()
-     env)))
-|#
+env)))

--- a/src/prelude/core/prelude.l
+++ b/src/prelude/core/prelude.l
@@ -29,7 +29,7 @@
       ;;; exception
       (prelude:define-type "%except"
           '((:cond   . :symbolp)
-            (:value . :t)
+            (:value  . :t)
             (:source . :symbolp)
             (:reason . :string)
             (:env    . :listp)))

--- a/tests/prelude/lambda
+++ b/tests/prelude/lambda
@@ -20,4 +20,6 @@
 (prelude:apply (prelude:compile '(lambda (a b c d &rest e) e)) '(1 2 3 4 5))	(5)
 (prelude:apply (prelude:compile '(lambda (a b c d e &rest f) f)) '(1 2 3 4 5))	:nil
 (prelude:apply (prelude:compile '(lambda (a b c d &rest f) (mu:write f () mu:*standard-output*))) '(1 2 3 4 5))	(5)(5)
+(prelude:apply (prelude:compile '(lambda () ((lambda ())))) ())	:nil
+(prelude:apply (prelude:compile '(lambda () ((lambda () 1 2 3)))) ())	3
 (mu:type-of (prelude:apply (prelude:compile '(lambda (a) (a))) (mu:cons (:lambda () 1) ())))	:fixnum

--- a/tests/tests.summary
+++ b/tests/tests.summary
@@ -26,7 +26,7 @@ prelude    prelude        total: 18       pass: 18       fail: 0        exceptio
 prelude    exception      total: 7        pass: 7        fail: 0        exceptions: 0       
 prelude    fixnum         total: 16       pass: 16       fail: 0        exceptions: 0       
 prelude    format         total: 15       pass: 15       fail: 0        exceptions: 0       
-prelude    lambda         total: 23       pass: 23       fail: 0        exceptions: 0       
+prelude    lambda         total: 25       pass: 25       fail: 0        exceptions: 0       
 prelude    list           total: 80       pass: 80       fail: 0        exceptions: 0       
 prelude    macro          total: 13       pass: 13       fail: 0        exceptions: 0       
 prelude    reader         total: 66       pass: 66       fail: 0        exceptions: 0       
@@ -36,5 +36,5 @@ prelude    symbol         total: 3        pass: 3        fail: 0        exceptio
 prelude    types          total: 43       pass: 43       fail: 0        exceptions: 0       
 prelude    vector         total: 25       pass: 25       fail: 0        exceptions: 0       
 -----------------------
-prelude                   total: 409      pass: 397      fail: 10       exceptions: 2         
+prelude                   total: 411      pass: 399      fail: 10       exceptions: 2         
 


### PR DESCRIPTION
do a better job of compiling lexical symbol references

docs: no change
tests: add some lambda tests
regression: no change
srcs: revise lexical symbol compliation strategy in prelude/core