### PR TITLE
#435 - mu: update crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,21 +34,21 @@ codegen-units = 1
 inherits = "release"
 
 [dependencies]
-async-std = "1.12.0"
+async-std = "1.13.0"
 cpu-time = "1.0.0"
 ctrlc = "3.4.4"
 futures = { version = "0.3.30", features = [ "executor", "thread-pool" ]}
 futures-locks = "0.7.1"
 json = "0.12.4"
-lazy_static = "1.4.0"
+lazy_static = "1.5.0"
 memmap = "0.7.0"
 modular-bitfield = "0.11.2"
-nix = {version = "0.28.0", features = [ "feature" ]}
-num_enum = "0.7.1"
+nix = {version = "0.29.0", features = [ "feature" ]}
+num_enum = "0.7.3"
 page_size = "0.6.0"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-sysinfo_dot_h = "0.2.0"
+sysinfo_dot_h = "0.2.1"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = "0.5.4"
+tikv-jemallocator = "0.6.0"

--- a/src/mu-exec/Cargo.toml
+++ b/src/mu-exec/Cargo.toml
@@ -9,4 +9,4 @@ elf = "0.7.4"
 mu = { path = "../.." }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = "0.5.4"
+tikv-jemallocator = "0.6.0"

--- a/src/mu-ld/Cargo.toml
+++ b/src/mu-ld/Cargo.toml
@@ -10,4 +10,4 @@ json = "0.12.4"
 mu = { path = "../.." }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = "0.5.4"
+tikv-jemallocator = "0.6.0"

--- a/src/mu-server/Cargo.toml
+++ b/src/mu-server/Cargo.toml
@@ -12,4 +12,4 @@ oports = "1.0.0"
 mu = { path = "../.." }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = "0.5.4"
+tikv-jemallocator = "0.6.0"

--- a/src/mu-sys/Cargo.toml
+++ b/src/mu-sys/Cargo.toml
@@ -8,4 +8,4 @@ getopt = "1.1.3"
 mu = { path = "../.." }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = "0.5.4"
+tikv-jemallocator = "0.6.0"


### PR DESCRIPTION
update mu crates

docs: no change
tests: no change
srcs: Cargo.toml gets updated jemalloc, nix, and async-std versions