### PR TITLE
#448 - mux: verbose everything

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:
 	@echo "              MUX_DIR - mux install directory, default /usr/local/bin"
 
 world:
-	@echo '((nil . ((compile-command . "make -f mu.mk release"))))' > .dir-locals.el
+	@echo '((nil . ((compile-command . "mux build --release"))))' > .dir-locals.el
 	@etags `find src/mu -name '*.rs' -print`		
 	@touch .mu
 	@cargo build --release --workspace

--- a/tools/mux/Cargo.toml
+++ b/tools/mux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mux"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 
 [dependencies]

--- a/tools/mux/src/annotate.rs
+++ b/tools/mux/src/annotate.rs
@@ -34,6 +34,11 @@ impl Annotate {
             None => panic!(),
         };
 
+        match options.find_opt(&Opt::Verbose) {
+            Some(_) => println!("mux annotate: prof {} ref {}", profile_path, reference_path),
+            None => (),
+        };
+
         let mut annotate = Command::new("python3")
             .arg("/opt/mu/bin/annotate.py")
             .arg(profile_path)

--- a/tools/mux/src/bench.rs
+++ b/tools/mux/src/bench.rs
@@ -28,17 +28,14 @@ impl Bench {
     }
 
     pub fn base(options: &Options) {
-        let test_opt = options.options.iter().find(|opt| match opt {
-            Opt::Ntests(_) => true,
-            _ => false,
-        });
-
-        let ntests = match test_opt {
-            Some(opt) => match opt {
-                Opt::Ntests(n) => *n,
-                _ => panic!(),
-            },
+        let ntests = match options.opt_value(&Opt::Ntests("".to_string())) {
+            Some(n) => n.parse().unwrap(),
             None => 20u32,
+        };
+
+        match options.find_opt(&Opt::Verbose) {
+            Some(_) => println!("mux bench: base ntests {ntests}"),
+            None => (),
         };
 
         for test_dir in ["tests/footprint", "tests/performance"] {
@@ -55,17 +52,14 @@ impl Bench {
     }
 
     pub fn current(options: &Options) {
-        let test_opt = options.options.iter().find(|opt| match opt {
-            Opt::Ntests(_) => true,
-            _ => false,
-        });
-
-        let ntests = match test_opt {
-            Some(opt) => match opt {
-                Opt::Ntests(n) => *n,
-                _ => panic!(),
-            },
+        let ntests = match options.opt_value(&Opt::Ntests("".to_string())) {
+            Some(n) => n.parse().unwrap(),
             None => 20u32,
+        };
+
+        match options.find_opt(&Opt::Verbose) {
+            Some(_) => println!("mux bench: current ntests {ntests}"),
+            None => (),
         };
 
         let mut test = Command::new("make")

--- a/tools/mux/src/build.rs
+++ b/tools/mux/src/build.rs
@@ -17,10 +17,7 @@ impl Build {
             _ => false,
         });
 
-        match options.options.iter().find(|opt| match opt {
-            Opt::Verbose => true,
-            _ => false,
-        }) {
+        match options.find_opt(&Opt::Verbose) {
             Some(_) => match build_opt {
                 Some(style) => match style {
                     Opt::Debug => println!("mux: build debug"),

--- a/tools/mux/src/clean.rs
+++ b/tools/mux/src/clean.rs
@@ -12,6 +12,11 @@ pub struct Clean {}
 
 impl Clean {
     pub fn clean(options: &Options) {
+        match options.find_opt(&Opt::Verbose) {
+            Some(_) => println!("mux clean:"),
+            None => (),
+        };
+
         let dirs = ["dist", "tests/regression", "tests/footprint"];
 
         let mu = match Env::mu_home(options) {

--- a/tools/mux/src/commit.rs
+++ b/tools/mux/src/commit.rs
@@ -9,10 +9,7 @@ pub struct Commit {}
 
 impl Commit {
     pub fn commit(options: &Options) {
-        match options.options.iter().find(|opt| match opt {
-            Opt::Verbose => true,
-            _ => false,
-        }) {
+        match options.find_opt(&Opt::Verbose) {
             Some(_) => println!("mux commit: fmt clippy"),
             None => (),
         };

--- a/tools/mux/src/env.rs
+++ b/tools/mux/src/env.rs
@@ -2,7 +2,7 @@
 //  SPDX-License-Identifier: MIT
 #![allow(unused_imports)]
 use {
-    crate::options::Options,
+    crate::options::{Opt, Options},
     std::fs::ReadDir,
     std::path::{Path, PathBuf},
 };
@@ -31,10 +31,15 @@ impl Env {
         }
     }
 
-    pub fn printenv(_options: &Options) {
+    pub fn printenv(options: &Options) {
         let ewd = std::env::current_dir().unwrap();
 
-        match Self::mu_home(_options) {
+        match options.find_opt(&Opt::Verbose) {
+            Some(_) => println!("mux env:"),
+            None => (),
+        };
+
+        match Self::mu_home(options) {
             Some(path) => println!("{:?}", path),
             None => {
                 println!(

--- a/tools/mux/src/install.rs
+++ b/tools/mux/src/install.rs
@@ -1,11 +1,19 @@
 //  SPDX-FileCopyrightText: Copyright 2024 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
-use {crate::options::Options, std::process::Command};
+use {
+    crate::options::{Opt, Options},
+    std::process::Command,
+};
 
 pub struct Install {}
 
 impl Install {
-    pub fn install(_options: &Options) {
+    pub fn install(options: &Options) {
+        match options.find_opt(&Opt::Verbose) {
+            Some(_) => println!("mux install:"),
+            None => (),
+        };
+
         let mut install = Command::new("make")
             .args(["-C", "./dist"])
             .args(["-f", "install.mk"])

--- a/tools/mux/src/main.rs
+++ b/tools/mux/src/main.rs
@@ -31,7 +31,7 @@ use {
     },
 };
 
-const VERSION: &str = "0.0.6";
+const VERSION: &str = "0.0.7";
 
 pub fn usage() {
     println!("Usage: mux {} command [option...]", VERSION);
@@ -48,7 +48,7 @@ pub fn usage() {
     println!("    symbols   [--crossref | --counts | --reference | --namespace]");
     println!("                                       ; symbol reports");
     println!("    test                               ; regression test suite");
-    println!("    bench     [--base | --current | --footprint | --ntests]");
+    println!("    bench     [[--base | --current | --footprint] | --ntests]");
     println!("    profile   [--config]               ; create profile");
     println!("    annotate  [--prof | --ref]         ; annotate profile");
     println!();

--- a/tools/mux/src/options.rs
+++ b/tools/mux/src/options.rs
@@ -19,7 +19,7 @@ pub enum Opt {
     Footprint,
     Load(String),
     Namespace(String),
-    Ntests(u32),
+    Ntests(String),
     Output(String),
     Profile,
     Prof(String),
@@ -35,7 +35,30 @@ impl Options {
         std::process::exit(0)
     }
 
-    pub fn option_name(opt: Opt) -> String {
+    pub fn find_opt(&self, opt: &Opt) -> Option<&Opt> {
+        self.options
+            .iter()
+            .find(|next_opt| std::mem::discriminant(*next_opt) == std::mem::discriminant(opt))
+    }
+
+    pub fn opt_value(&self, opt: &Opt) -> Option<String> {
+        match self.find_opt(opt) {
+            Some(opt) => match opt {
+                Opt::Config(str)
+                | Opt::Eval(str)
+                | Opt::Load(str)
+                | Opt::Namespace(str)
+                | Opt::Prof(str)
+                | Opt::Output(str)
+                | Opt::Ref(str)
+                | Opt::Ntests(str) => Some(str.to_string()),
+                _ => panic!(),
+            },
+            None => None,
+        }
+    }
+
+    pub fn opt_name(opt: Opt) -> String {
         match opt {
             Opt::Base => "base",
             Opt::Config(_) => "config",
@@ -93,6 +116,7 @@ impl Options {
             "footprint",
             "load",
             "namespace",
+            "ntests",
             "output",
             "prof",
             "profile",
@@ -124,9 +148,7 @@ impl Options {
                         "footprint" => options.push(Opt::Footprint),
                         "load" => options.push(Opt::Load(opts.opt_str(name).unwrap())),
                         "namespace" => options.push(Opt::Namespace(opts.opt_str(name).unwrap())),
-                        "ntests" => {
-                            options.push(Opt::Ntests(opts.opt_str(name).unwrap().parse().unwrap()))
-                        }
+                        "ntests" => options.push(Opt::Ntests(opts.opt_str(name).unwrap())),
                         "output" => options.push(Opt::Output(opts.opt_str(name).unwrap())),
                         "prof" => options.push(Opt::Prof(opts.opt_str(name).unwrap())),
                         "profile" => options.push(Opt::Profile),

--- a/tools/mux/src/profile.rs
+++ b/tools/mux/src/profile.rs
@@ -8,65 +8,57 @@ pub struct Profile {}
 
 impl Profile {
     pub fn profile(options: &Options) {
-        let config_opt = options.options.iter().find(|opt| match opt {
-            Opt::Config(_) => true,
-            _ => false,
-        });
+        match options.find_opt(&Opt::Verbose) {
+            Some(_) => println!("mux profile:"),
+            None => (),
+        };
 
-        let output_opt = options.options.iter().find(|opt| match opt {
-            Opt::Output(_) => true,
-            _ => false,
-        });
+        let config_opt = options.opt_value(&Opt::Config("".to_string()));
+        let output_opt = options.opt_value(&Opt::Output("".to_string()));
 
         match config_opt {
-            Some(opt) => match opt {
-                Opt::Config(config) => {
-                    let profile_expr =
-                        &format!("((:lambda (config)                          \
-                                      (prelude:load (mu:car config) ())       \
-                                      ((:lambda (entry)                       \
-                                          (prof:prof-control :on)             \
-                                          (mu:apply (mu:symbol-value entry) (mu:nthcdr 2 config)) \
-                                          (prof:prof-control :off)            \
-                                          (core:%map-vector                   \
-                                            (:lambda (fn-count)               \
-                                               (core:format :t \"~A~T~A~%\" `(,(mu:car fn-count) ,(mu:cdr fn-count)))) \
-                                            (prof:prof-control :get)))           \
-                                        (mu:intern mu:%null-ns% (mu:nth 1 config) ()))) \
-                                    '{})", config);
+            Some(config) => {
+                let profile_expr =
+                    &format!("((:lambda (config)                      \
+                              (prelude:load (mu:car config) ())       \
+                              ((:lambda (entry)                       \
+                              (prof:prof-control :on)                 \
+                              (mu:apply (mu:symbol-value entry) (mu:nthcdr 2 config)) \
+                              (prof:prof-control :off)                \
+                              (core:%map-vector                       \
+                              (:lambda (fn-count)                     \
+                              (core:format :t \"~A~T~A~%\" `(,(mu:car fn-count) ,(mu:cdr fn-count)))) \
+                              (prof:prof-control :get)))              \
+                              (mu:intern mu:%null-ns% (mu:nth 1 config) ()))) \
+                              '{})", config);
 
-                    match output_opt {
-                        Some(opt) => match opt {
-                            Opt::Output(path) => {
-                                let out_file =
-                                    File::create(path).expect(&format!("failed to open {path}"));
+                match output_opt {
+                    Some(path) => {
+                        let out_file =
+                            File::create(path.clone()).expect(&format!("failed to open {path}"));
 
-                                Command::new("mu-sys")
-                                    .arg("-p")
-                                    .args(["-l", "/opt/mu/dist/core.l"])
-                                    .args(["-l", "/opt/mu/dist/common.l"])
-                                    .args(["-l", "/opt/mu/dist/prelude.l"])
-                                    .args(["-e", profile_expr])
-                                    .stdout(out_file)
-                                    .spawn()
-                                    .unwrap();
-                            }
-                            _ => (),
-                        },
-                        None => {
-                            Command::new("mu-sys")
-                                .arg("-p")
-                                .args(["-l", "/opt/mu/dist/core.l"])
-                                .args(["-l", "/opt/mu/dist/common.l"])
-                                .args(["-l", "/opt/mu/dist/prelude.l"])
-                                .args(["-e", profile_expr])
-                                .spawn()
-                                .unwrap();
-                        }
+                        Command::new("mu-sys")
+                            .arg("-p")
+                            .args(["-l", "/opt/mu/dist/core.l"])
+                            .args(["-l", "/opt/mu/dist/common.l"])
+                            .args(["-l", "/opt/mu/dist/prelude.l"])
+                            .args(["-e", profile_expr])
+                            .stdout(out_file)
+                            .spawn()
+                            .unwrap();
+                    }
+                    None => {
+                        Command::new("mu-sys")
+                            .arg("-p")
+                            .args(["-l", "/opt/mu/dist/core.l"])
+                            .args(["-l", "/opt/mu/dist/common.l"])
+                            .args(["-l", "/opt/mu/dist/prelude.l"])
+                            .args(["-e", profile_expr])
+                            .spawn()
+                            .unwrap();
                     }
                 }
-                _ => panic!(),
-            },
+            }
             None => {
                 eprintln!("profile switches: config output annotate");
                 if options.options.is_empty() {
@@ -74,7 +66,7 @@ impl Profile {
                 } else {
                     eprintln!("     unrecognized switch(es)");
                     for opt in &options.options {
-                        eprintln!("     {}", Options::option_name(opt.clone()))
+                        eprintln!("     {}", Options::opt_name(opt.clone()))
                     }
                 }
             }

--- a/tools/mux/src/repl.rs
+++ b/tools/mux/src/repl.rs
@@ -9,17 +9,14 @@ pub struct Repl {}
 
 impl Repl {
     pub fn repl(options: &Options) {
-        let ns_opt = options.options.iter().find(|opt| match opt {
-            Opt::Namespace(_) => true,
-            _ => false,
-        });
-
-        let ns_str = match ns_opt {
+        let ns_str = match options.opt_value(&Opt::Namespace("".to_string())) {
+            Some(ns) => &ns.clone(),
             None => "mu",
-            Some(opt) => match opt {
-                Opt::Namespace(ns) => ns,
-                _ => panic!(),
-            },
+        };
+
+        match options.find_opt(&Opt::Verbose) {
+            Some(_) => println!("mux ns: {ns_str}"),
+            None => (),
         };
 
         let mut child = match ns_str {

--- a/tools/mux/src/symbols.rs
+++ b/tools/mux/src/symbols.rs
@@ -16,6 +16,11 @@ impl Symbols {
             _ => false,
         });
 
+        match options.find_opt(&Opt::Verbose) {
+            Some(_) => println!("mux symbols: {report_opt:?}"),
+            None => (),
+        };
+
         match report_opt {
             Some(opt) => match opt {
                 Opt::Crossref => Self::crossref(options),

--- a/tools/mux/src/test.rs
+++ b/tools/mux/src/test.rs
@@ -1,11 +1,19 @@
 //  SPDX-FileCopyrightText: Copyright 2024 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
-use {crate::options::Options, std::process::Command};
+use {
+    crate::options::{Opt, Options},
+    std::process::Command,
+};
 
 pub struct Test {}
 
 impl Test {
-    pub fn test(_options: &Options) {
+    pub fn test(options: &Options) {
+        match options.find_opt(&Opt::Verbose) {
+            Some(_) => println!("mux test:"),
+            None => (),
+        };
+
         let mut test = Command::new("make")
             .args(["-C", "tests/regression"])
             .arg("summary")


### PR DESCRIPTION
add verbose output to all commands, mux version now 0.0.7

docs: no change
tests: no change
srcs: mux, clean up option handling, enhance commands