### PR TITLE
#46 - core: macro expansion evaluates args

### DIFF
--- a/src/common/sequence.l
+++ b/src/common/sequence.l
@@ -259,7 +259,6 @@ Function SUBSTITUTE, SUBSTITUTE-IF, SUBSTITUTE-IF-NOT
              (mu:fix
               (:lambda (loop)
                 ((:lambda (nth list)
-                   (core:warn list "list:")
                    (:if (mu:eq nth (common:length seq))
                         loop
                         (mu:cons (common:1+ nth) (mu:cons (common:elt seq nth) list))))

--- a/src/core/exception.l
+++ b/src/core/exception.l
@@ -97,7 +97,7 @@
 
 (mu:intern core "warn"
    (:lambda (value message)
-     (core:format mu:*error-output* ";;; ~S ; ~A, type ~A~%" `(,value ,message ,(mu:type-of value)))
+     (core:format mu:*error-output* ";;; warn: ~A (~A) ; ~S~%" `(,message ,(mu:type-of value) ,value))
     value))
 
 ;;;

--- a/src/core/funcall.l
+++ b/src/core/funcall.l
@@ -33,19 +33,19 @@
            (core:%arg-list arg-list))))
 
 (mu:intern core "%quoted-lambda-arg-list"
-  (:lambda (fn args)
-    (:if (core:%closurep fn)
-         (:if (core:%closure-prop :rest fn)
-              (:if (core:%andf (core:%closure-prop :rest fn) (mu:eq 0 (core:%closure-prop :arity fn)))
-                   (mu:cons args ())
-                   ((:lambda (reqs rest)
-                      (core:%append
-                       reqs
-                       (mu:cons rest ())))
-                    (core:%dropr args (mu:sub (mu:length args) (core:%closure-prop :arity fn)))
-                    (core:%dropl args (core:%closure-prop :arity fn))))
-              args)
-         args)))
+   (:lambda (fn args)
+     (:if (core:%closurep fn)
+          (:if (core:%closure-prop :rest fn)
+               (:if (core:%andf (core:%closure-prop :rest fn) (mu:eq 0 (core:%closure-prop :arity fn)))
+                    (mu:cons args ())
+                    ((:lambda (reqs rest)
+                       (:if (core:%andf (core:null rest) (core:null reqs))
+                            ()
+                            `(,(core:%append reqs) ,rest)))
+                     (core:%dropr args (mu:sub (mu:length args) (core:%closure-prop :arity fn)))
+                     (core:%dropl args (core:%closure-prop :arity fn))))
+               args)
+          args)))
 
 ;;;
 ;;; compile argument lists
@@ -67,8 +67,8 @@
 
 (mu:intern core "%compile-quoted-lambda-arg-list"
    (:lambda (function arg-list env)
-     (core:%compile-lambda-arg-list function (core:%mapcar (:lambda (elt) (core:%compile elt env)) arg-list))))
-
+     (core:%quoted-lambda-arg-list function arg-list)))
+     
 ;;;
 ;;; compile function applications to mu forms
 ;;;
@@ -101,7 +101,6 @@
         (core:%mapc mu:%frame-push env)
         (core:%mapc (:lambda (frame) (mu:%frame-pop (mu:car frame))) env)
         ((:lambda (lib-fn frame-fn)
-           ;;; (core:warn (mu:apply frame-fn `(,lib-fn ,arg-list)) "apply")
            (mu:apply lib-fn (mu:eval (core:%lambda-arg-list fn arg-list))))
          (core:%closure-prop :fn fn)
          (core:%lambda-prop :frame (core:%closure-prop :lambda fn))))
@@ -109,11 +108,14 @@
 
 (mu:intern core "%fn-apply-quoted"
    (:lambda (fn arg-list)
-      ((:lambda (env)
-         (core:%mapc mu:%frame-push env)
-         (core:%mapc (:lambda (frame) (mu:%frame-pop (mu:car frame))) env)
-         (mu:apply (core:%closure-prop :fn fn) arg-list))
-       (core:%closure-prop :env fn))))
+     ((:lambda (env)
+        (core:%mapc mu:%frame-push env)
+        (core:%mapc (:lambda (frame) (mu:%frame-pop (mu:car frame))) env)
+        ((:lambda (lib-fn frame-fn)
+           (mu:apply lib-fn arg-list))
+         (core:%closure-prop :fn fn)
+         (core:%lambda-prop :frame (core:%closure-prop :lambda fn))))
+      (core:%closure-prop :env fn))))
 
 (mu:intern core "%apply"
    (:lambda (function arg-list)

--- a/src/core/macro.l
+++ b/src/core/macro.l
@@ -14,6 +14,7 @@
        (mu:symbol-namespace symbol)
        (mu:symbol-name symbol))))
 
+#|
 (mu:intern core "%describe-fn"
    (:lambda (fn)
      (:if (core:%closurep fn)
@@ -28,18 +29,18 @@
            (core:%closure-prop :fn fn)
            (core:%closure-prop :env fn))
           (core:print (mu:view fn) "%describe-fn:mu-fn"))))
+|#
 
 (mu:intern core "%compile-macro-call"
    (:lambda (macro-symbol arg-list env)
      ((:lambda (macro-function)
         ;;; (core:%describe-fn macro-function)
-        ;;; (core:warn arg-list "%compile-macro-call on")
         ((:lambda (expanded-form)
            (core:%compile expanded-form env))
          (:if (core:%closurep macro-function)
               (core:%fn-apply-quoted
                macro-function
-               (mu:eval (core:%compile-lambda-arg-list macro-function arg-list env)))
+               (core:%compile-quoted-lambda-arg-list macro-function arg-list env))
               (mu:apply macro-function arg-list))))
       (core:%macro-function macro-symbol env))))
 
@@ -47,7 +48,7 @@
 ;;; functions
 ;;;
 (mu:intern core "%macroexpand-1"
-   (:lambda (form env)
+   (:lambda (form env)          
      (:if (core:%consp form)
           ((:lambda (fn-symbol arg-list)
              (:if (mu:eq :symbol (mu:type-of fn-symbol))
@@ -63,16 +64,6 @@
            (mu:car form)
            (mu:cdr form))
           form)))
-
-#|
-(mu:intern core "%macroexpand"
-   (:lambda (form env)
-     ((:lambda (expanded)
-          (:if (mu:eq form expanded)
-             expanded
-             (core:%macroexpand expanded env)))
-       (core:%macroexpand-1 form env))))
-|#
 
 (mu:intern core "%macroexpand"
    (:lambda (form env)

--- a/tools/crossref/Makefile
+++ b/tools/crossref/Makefile
@@ -7,7 +7,7 @@ help:
 	@echo "crossref: mu/core symbol cross reference"
 
 crossref:
-	@mu --pipe --load=./crossref.l --quiet-eval='(crossref \"crossref.out\")'
+	/opt/mu/bin/mu-sys -l /opt/mu/dist/core.l -l ./crossref.l -q \(crossref \"crossref.out\"\)
 	@python3 crossref.py crossref.out
 
 clean:


### PR DESCRIPTION
macro expansion finally working right, progn/when/unless/let expanders functional

docs: no change
tests: shaved bonus 750 bytes from  macro tests
srcs: rework core macro expansion