### PR TITLE
#476 - core: check ((lambda (...) ...) ...) syntax

### DIFF
--- a/src/core/funcall.l
+++ b/src/core/funcall.l
@@ -62,23 +62,6 @@
             (mu:length (core:%core-function-prop :require function)))
            (core:%quoted-arg-list arg-list))))
 
-#|
-(mu:intern core "%quoted-lambda-arg-list"
-   (:lambda (fn args)
-     (:if (core:%core-function-p fn)
-          (:if (core:%core-function-prop :rest fn)
-               (:if (core:logand (core:%core-function-prop :rest fn) (mu:eq 0 (core:%core-function-prop :arity fn)))
-                    (mu:cons args ())
-                    ((:lambda (reqs rest)
-                       (:if (core:logand (core:null rest) (core:null reqs))
-                            ()
-                            (core:%arg-list `(,@reqs ,(core:%arg-list rest)))))
-                     (core:%dropr args (mu:sub (mu:length args) (core:%core-function-prop :arity fn)))
-                     (core:%dropl args (mu:length (core:%core-function-prop :require function)))))
-               args)
-          args)))
-|#
-
 ;;;
 ;;; compile argument lists
 ;;;
@@ -119,7 +102,7 @@
                                `(,core:%fapply
                                  ,function
                                  ,mu-form
-                                 ,(mu:cons (core:%compile-lambda-arg-list function arg-list env) ()))
+                                 ,(core:%compile-lambda-arg-list function arg-list env))
                                `(,core:%fapply
                                  ,function
                                  ,mu-form

--- a/tests/regression/core/compile
+++ b/tests/regression/core/compile
@@ -1,8 +1,8 @@
 (mu:eq :func (mu:type-of core:compile))	:t
-(mu:eq :func (mu:type-of (core:compile '(lambda () 1))))	:t
-(mu:eq :func (mu:type-of (core:compile '(lambda (a b) b))))	:t
-(mu:eq :func (mu:type-of (core:compile '(lambda (a) "hoo"))))	:t
-(mu:eq :func (mu:type-of (core:compile '(lambda (a) a))))	:t
+(mu:eq :struct (mu:type-of (core:compile '(lambda () 1))))	:t
+(mu:eq :struct (mu:type-of (core:compile '(lambda (a b) b))))	:t
+(mu:eq :struct (mu:type-of (core:compile '(lambda (a) "hoo"))))	:t
+(mu:eq :struct (mu:type-of (core:compile '(lambda (a) a))))	:t
 (mu:eval (core:compile '(if :t :t ())))	:t
 (mu:eval (core:compile '(if () () :t)))	:t
 (mu:eval (core:compile '(if :t () :t)))	:nil

--- a/tests/regression/core/lambda
+++ b/tests/regression/core/lambda
@@ -20,4 +20,26 @@
 (core:apply (core:compile '(lambda (a b c d &rest e) e)) '(1 2 3 4 5))	(5)
 (core:apply (core:compile '(lambda (a b c d e &rest f) f)) '(1 2 3 4 5))	:nil
 (core:apply (core:compile '(lambda (a b c d &rest f) (mu:write f () mu:*standard-output*))) '(1 2 3 4 5))	(5)(5)
+(mu:eval (core:compile '((lambda () 1))))	1
+(mu:eval (core:compile '((lambda (a b) (core:null b)) 1 2)))	:nil
+(mu:eval (core:compile '((lambda (a b) (mu:add 1 2)) 1 2)))	3
+(mu:eval (core:compile '((lambda (a b) (mu:add a b)) 1 2)))	3
+(mu:eval (core:compile '((lambda (a b) (mu:type-of b)) 1 2)))	:fixnum
+(mu:eval (core:compile '((lambda ()))))	:nil
+(mu:eval (core:compile '((lambda () 1))))	1
+(mu:eval (core:compile '((lambda (a) a) 1)))	1
+(mu:eval (core:compile '((lambda (a) 1) 2)))	1
+(mu:eval (core:compile '((lambda (a b) 1) 2 3)))	1
+(mu:eval (core:compile '((lambda (a b) (core:%fixnump b)) 1 2)))	:t
+(mu:eval (core:compile '((lambda (a b) (core:null b)) 1 2)))	:nil
+(mu:eval (core:compile '((lambda (a b) (mu:add 1 2)) 1 2)))	3
+(mu:eval (core:compile '((lambda (a b) (mu:add a b)) 1 2)))	3
+(mu:eval (core:compile '((lambda (a b) (mu:type-of b)) 1 2)))	:fixnum
+(mu:eval (core:compile '((lambda (&rest e) e) 1 2 3 4 5)))	(1 2 3 4 5)
+(mu:eval (core:compile '((lambda (a &rest e) e) 1 2 3 4 5)))	(2 3 4 5)
+(mu:eval (core:compile '((lambda (a b &rest e) e) 1 2 3 4 5)))	(3 4 5)
+(mu:eval (core:compile '((lambda (a b c &rest e) e) 1 2 3 4 5)))	(4 5)
+(mu:eval (core:compile '((lambda (a b c d &rest e) e) 1 2 3 4 5)))	(5)
+(mu:eval (core:compile '((lambda (a b c d e &rest f) f) 1 2 3 4 5)))	:nil
+(mu:eval (core:compile '((lambda (a b c d &rest f) (mu:write f () mu:*standard-output*)) 1 2 3 4 5)))	(5)(5)
 (mu:type-of (core:apply (core:compile '(lambda (a) (mu:apply a ()))) (mu:cons (:lambda () 1) ())))	:fixnum


### PR DESCRIPTION
fix funcall compiler for the ((lambda (...) ...) ...) syntax

docs: no change
tests: add regression tests for the above
srcs: change the way argument lists are computed for this case