### PR TITLE
#501 - core: add basic rest functions and macros

### DIFF
--- a/dist/dist.mk
+++ b/dist/dist.mk
@@ -28,7 +28,8 @@ CORE= \
 	function.l     \
 	apply.l	       \
 	package.l      \
-	vector.l 
+	vector.l       \
+	core-symbols.l
 
 COMMON= \
 	common.l       \

--- a/src/common/common.l
+++ b/src/common/common.l
@@ -34,6 +34,7 @@
            (mu:cdr loop)))
         (mu:cons () args))))))
 
+#|
 ;;;
 ;;; macros
 ;;;
@@ -103,6 +104,7 @@
             term)))
     ()
     (core:%maplist common:identity terms))))
+|#
 
 #|
 (core:compile '(%defmacro progn (&rest body) (common:list (common:list* 'lambda () body))))

--- a/src/core/core-symbols.l
+++ b/src/core/core-symbols.l
@@ -1,0 +1,100 @@
+;;;  SPDX-FileCopyrightText: Copyright 2017 James M. Putnam (putnamjm.design@gmail.com)
+;;;  SPDX-License-Identifier: MIT
+
+;;;
+;;; core macros
+;;;
+
+;;;
+;;; rest functions
+;;;
+(mu:intern core "append"
+   (core:compile '(lambda (&rest list) (mu:%append list))))
+
+(mu:intern core "list"
+   (core:compile '(lambda (&rest list) list)))         
+
+(mu:intern core "list*"
+   (core:compile
+    '(lambda (&rest args)
+      (mu:car
+       (mu:fix
+        (:lambda (loop)
+          ((:lambda (list args)
+             (:if args
+                  (:if (mu:cdr args)
+                       (mu:cons (mu:append list (mu:cons (mu:car args) ())) (mu:cdr args))
+                       (mu:cons (mu:append list (mu:car args)) ()))
+                  loop))
+           (mu:car loop)
+           (mu:cdr loop)))
+        (mu:cons () args))))))
+
+;;;
+;;; macros
+;;;
+(core:compile
+ '(%defmacro progn (&rest body)
+   `((lambda () ,@body))))
+
+(core:compile
+ '(%defmacro when (test &rest body)
+   `(if ,test (progn ,@body))))
+
+(core:compile
+ '(%defmacro unless (test &rest body)
+   `(if (core:null ,test) (progn ,@body))))
+
+(core:compile
+ '(%defmacro let (binds &rest body)
+   `((lambda ,(core:%mapcar mu:car binds) ,@body)
+     ,@(core:%mapcar (:lambda (bind) (mu:nth 1 bind)) binds))))
+
+(core:compile
+ '(%defmacro let* (binds &rest body)
+   (:if binds
+       `(let (,(mu:car binds)) (let* ,(mu:cdr binds) ,@body))
+       `(let () ,@body))))
+
+(core:compile
+ '(%defmacro cond (&rest clauses)
+   (core:%foldr
+    (:lambda (clause cond-form)
+      ((:lambda (test body)
+         `(if ,test (progn ,@body) ,cond-form))
+       (mu:car clause)
+       (mu:cdr clause)))
+      ()
+      clauses)))
+
+(core:compile
+ '(%defmacro and (&rest terms)
+   (:if terms
+    (:if (mu:eq 1 (mu:length terms))
+     (mu:car terms)
+     (core:%foldl
+      (:lambda (term acc)
+        `(if ,acc ,term))
+      `(if ,(mu:nth 0 terms) ,(mu:nth 1 terms))
+      (mu:nthcdr 2 terms)))
+    :t)))
+
+(core:compile
+ '(%defmacro or (&rest terms)
+   (:if terms
+    (:if (mu:eq 1 (mu:length terms))
+     (mu:car terms)
+     (core:%foldl
+      (:lambda (term acc)
+        ((:lambda (g)
+           `(,acc (let ((,g ,term)) ,g)))
+         (core:gensym)))
+      ((:lambda (g1 g2)
+         `(let ((,g1 ,(mu:nth 0 terms)))
+            ,g1
+            (let ((,g2 ,(mu:nth 1 terms)))
+              ,g2)))
+       (core:gensym)
+       (core:gensym))
+      (mu:nthcdr 2 terms)))
+    ())))

--- a/tests/regression/core/core
+++ b/tests/regression/core/core
@@ -1,0 +1,43 @@
+(mu:eval (core:compile '(core:append)))	:nil
+(mu:eval (core:compile '(core:append '(1 2 3) 4)))	(1 2 3 . 4)
+(mu:eval (core:compile '(core:append '(1 2 3) '(4))))	(1 2 3 4)
+(mu:eval (core:compile '(core:list)))	:nil
+(mu:eval (core:compile '(core:list 1)))	(1)
+(mu:eval (core:compile '(core:list 1 2 3)))	(1 2 3)
+(mu:eval (core:compile '(core:list*)))	:nil
+(mu:eval (core:compile '(core:list* 1)))	1
+(mu:eval (core:compile '(core:list* 1 2 3)))	(1 2 . 3)
+(mu:eval (core:compile '(core:let ())))	:nil
+(mu:eval (core:compile '(core:let () 1)))	1
+(mu:eval (core:compile '(core:let () 1 2)))	2
+(mu:eval (core:compile '(core:let ((a 0)) a)))	0
+(mu:eval (core:compile '(core:let ((a 1) (b 2)) (mu:add a b))))	3
+(mu:eval (core:compile '(core:let* ())))	:nil
+(mu:eval (core:compile '(core:let* () 1)))	1
+(mu:eval (core:compile '(core:let* () 1 2)))	2
+(mu:eval (core:compile '(core:let* ((a 0)) a)))	0
+(mu:eval (core:compile '(core:let* ((a 1) (b 2)) (mu:add a b))))	3
+(mu:eval (core:compile '(progn)))	:nil
+(mu:eval (core:compile '(progn 1)))	1
+(mu:eval (core:compile '(progn 1 2)))	2
+(mu:eval (core:compile '(when :t ())))	:nil
+(mu:eval (core:compile '(when :t 1)))	1
+(mu:eval (core:compile '(when :t 1 2)))	2
+(mu:eval (core:compile '(when () ())))	:nil
+(mu:eval (core:compile '(when () 1)))	:nil
+(mu:eval (core:compile '(when () 1 2)))	:nil
+(mu:eval (core:compile '(unless :t ())))	:nil
+(mu:eval (core:compile '(unless :t 1)))	:nil
+(mu:eval (core:compile '(unless :t 1 2)))	:nil
+(mu:eval (core:compile '(unless () ())))	:nil
+(mu:eval (core:compile '(unless () 1)))	1
+(mu:eval (core:compile '(unless () 1 2)))	2
+(mu:eval (core:compile '(and)))	:t
+(mu:eval (core:compile '(and 1)))	1
+(mu:eval (core:compile '(and 1 2)))	2
+(mu:eval (core:compile '(or)))	:nil
+(mu:eval (core:compile '(or 1)))	1
+(mu:eval (core:compile '(or 1 2)))	2
+(mu:eval (core:compile '(cond)))	:nil
+(mu:eval (core:compile '(cond (1 'a))))	a
+(mu:eval (core:compile '(cond (() 'a) (1 'b 'c))))	c

--- a/tests/regression/core/tests
+++ b/tests/regression/core/tests
@@ -1,4 +1,5 @@
 backquote
+core
 closure
 compile
 prelude


### PR DESCRIPTION
append, list, and list*, progn, and, or, cond, let, let*, etc

docs: no change
tests: add core rest function and macro tests to regression, slight improvement in heap overhead performance
srcs: new file in core, fix dist mechanims accordingly