### PR TITLE
#511 - mu: prefer into() to to_()

### DIFF
--- a/src/mu/core/compile.rs
+++ b/src/mu/core/compile.rs
@@ -53,7 +53,7 @@ impl Compile for Env {
         let lambda = Symbol::keyword("lambda");
 
         let if_vec = vec![
-            Namespace::intern(self, self.mu_ns, "%if".to_string(), Tag::nil()).unwrap(),
+            Namespace::intern(self, self.mu_ns, "%if".into(), Tag::nil()).unwrap(),
             Cons::list(
                 self,
                 &[lambda, Tag::nil(), Cons::nth(self, 0, args).unwrap()],
@@ -154,8 +154,7 @@ impl Compile for Env {
 
             if let Some(nth) = symbols.iter().position(|lex| symbol.eq_(lex)) {
                 let lex_ref = vec![
-                    Namespace::intern(self, self.mu_ns, "%frame-ref".to_string(), Tag::nil())
-                        .unwrap(),
+                    Namespace::intern(self, self.mu_ns, "%frame-ref".into(), Tag::nil()).unwrap(),
                     *tag,
                     Fixnum::with_or_panic(nth),
                 ];

--- a/src/mu/core/direct.rs
+++ b/src/mu/core/direct.rs
@@ -73,7 +73,7 @@ impl DirectTag {
         }
     }
 
-    pub fn to_direct(data: u64, ext: DirectExt, tag: DirectType) -> Tag {
+    pub fn to_tag(data: u64, ext: DirectExt, tag: DirectType) -> Tag {
         let ext: u8 = match ext {
             DirectExt::Length(size) => size as u8,
             DirectExt::ExtType(ext_type) => ext_type as u8,
@@ -113,7 +113,7 @@ impl DirectTag {
         let car_ = Self::sext_from_tag(car)?;
 
         Self::sext_from_tag(cdr).map(|cdr_| {
-            Self::to_direct(
+            Self::to_tag(
                 (car_ as u64) << 28 | cdr_ as u64,
                 DirectExt::ExtType(ExtType::Cons),
                 DirectType::Ext,

--- a/src/mu/core/dynamic.rs
+++ b/src/mu/core/dynamic.rs
@@ -56,7 +56,7 @@ impl CoreFunction for Env {
         let mut frames = Vec::new();
 
         frames.extend(frames_ref.iter().map(|(func, offset)| {
-            let mut argv = Vec::new();
+            let mut argv = vec![];
 
             Frame::frame_stack_ref(env, (&func.to_le_bytes()).into(), *offset, &mut argv);
 

--- a/src/mu/core/exception.rs
+++ b/src/mu/core/exception.rs
@@ -94,7 +94,7 @@ impl fmt::Display for Exception {
 
 impl Exception {
     pub fn new(env: &Env, condition: Condition, symbol: &str, object: Tag) -> Self {
-        let source = Symbol::parse(env, symbol.to_string()).unwrap();
+        let source = Symbol::parse(env, symbol.into()).unwrap();
 
         Exception {
             object,
@@ -104,24 +104,16 @@ impl Exception {
     }
 
     fn map_condition(env: &Env, keyword: Tag) -> Result<Condition> {
-        #[allow(clippy::unnecessary_to_owned)]
-        let condmap = CONDMAP
-            .to_vec()
-            .into_iter()
-            .find(|cond| keyword.eq_(&cond.0));
+        let condmap = CONDMAP.iter().find(|cond| keyword.eq_(&cond.0));
 
         match condmap {
-            Some(entry) => Ok(entry.1),
+            Some(entry) => Ok(entry.1.clone()),
             _ => Err(Exception::new(env, Condition::Syntax, "mu:raise", keyword)),
         }
     }
 
     fn map_condkey(cond: Condition) -> Result<Tag> {
-        #[allow(clippy::unnecessary_to_owned)]
-        let condmap = CONDMAP
-            .to_vec()
-            .into_iter()
-            .find(|condtab| cond == condtab.1);
+        let condmap = CONDMAP.iter().find(|condtab| cond == condtab.1);
 
         match condmap {
             Some(entry) => Ok(entry.0),

--- a/src/mu/core/frame.rs
+++ b/src/mu/core/frame.rs
@@ -39,7 +39,7 @@ pub struct Frame {
 
 impl Frame {
     fn to_tag(&self, env: &Env) -> Tag {
-        let vec = self.argv.to_vec();
+        let vec = self.argv.clone();
 
         Struct::new(env, "frame", vec).evict(env)
     }

--- a/src/mu/core/lib.rs
+++ b/src/mu/core/lib.rs
@@ -123,26 +123,18 @@ impl Lib {
         Namespace::intern_static(
             env,
             env.mu_ns,
-            "*version*".to_string(),
+            "*version*".into(),
             Vector::from(LIB.version).evict(env),
         )
         .unwrap();
 
-        Namespace::intern_static(env, env.mu_ns, "%null-ns%".to_string(), env.null_ns);
+        Namespace::intern_static(env, env.mu_ns, "%null-ns%".into(), env.null_ns);
 
-        Namespace::intern_static(env, env.mu_ns, "*standard-input*".to_string(), LIB.stdin())
-            .unwrap();
+        Namespace::intern_static(env, env.mu_ns, "*standard-input*".into(), LIB.stdin()).unwrap();
 
-        Namespace::intern_static(
-            env,
-            env.mu_ns,
-            "*standard-output*".to_string(),
-            LIB.stdout(),
-        )
-        .unwrap();
+        Namespace::intern_static(env, env.mu_ns, "*standard-output*".into(), LIB.stdout()).unwrap();
 
-        Namespace::intern_static(env, env.mu_ns, "*error-output*".to_string(), LIB.errout())
-            .unwrap();
+        Namespace::intern_static(env, env.mu_ns, "*error-output*".into(), LIB.errout()).unwrap();
 
         for (name, nreqs, fn_) in &*LIB_SYMBOLS {
             let vec = vec![
@@ -154,7 +146,7 @@ impl Lib {
             let fn_vec = Vector::from(vec).evict(env);
             let func = Function::new((*nreqs).into(), fn_vec).evict(env);
 
-            Namespace::intern_static(env, env.mu_ns, name.to_string(), func).unwrap();
+            Namespace::intern_static(env, env.mu_ns, (*name).into(), func).unwrap();
 
             functions.push(*fn_)
         }
@@ -177,7 +169,7 @@ impl Lib {
                 let fn_vec = Vector::from(vec).evict(env);
                 let func = Function::new((*nreqs).into(), fn_vec).evict(env);
 
-                Namespace::intern(env, ns, name.to_string(), func).unwrap();
+                Namespace::intern(env, ns, (*name).into(), func).unwrap();
 
                 functions.push(*fn_)
             }

--- a/src/mu/core/quasi.rs
+++ b/src/mu/core/quasi.rs
@@ -56,8 +56,8 @@ impl QuasiReader {
     pub fn new(env: &Env, stream: Tag) -> Self {
         Self {
             stream,
-            cons: Namespace::intern(env, env.mu_ns, "cons".to_string(), Tag::nil()).unwrap(),
-            qappend: Namespace::intern(env, env.mu_ns, "append".to_string(), Tag::nil()).unwrap(),
+            cons: Namespace::intern(env, env.mu_ns, "cons".into(), Tag::nil()).unwrap(),
+            qappend: Namespace::intern(env, env.mu_ns, "append".into(), Tag::nil()).unwrap(),
         }
     }
 

--- a/src/mu/core/reader.rs
+++ b/src/mu/core/reader.rs
@@ -33,7 +33,7 @@ use crate::{
 //
 
 lazy_static! {
-    pub static ref EOL: Tag = DirectTag::to_direct(0, DirectExt::Length(0), DirectType::Keyword);
+    pub static ref EOL: Tag = DirectTag::to_tag(0, DirectExt::Length(0), DirectType::Keyword);
 }
 
 pub trait Core {

--- a/src/mu/core/types.rs
+++ b/src/mu/core/types.rs
@@ -78,7 +78,7 @@ pub enum TagType {
 }
 
 lazy_static! {
-    static ref NIL: Tag = DirectTag::to_direct(
+    static ref NIL: Tag = DirectTag::to_tag(
         (('l' as u64) << 16) | (('i' as u64) << 8) | ('n' as u64),
         DirectExt::Length(3),
         DirectType::Keyword

--- a/src/mu/features/ffi.rs
+++ b/src/mu/features/ffi.rs
@@ -15,7 +15,7 @@ impl Ffi for Feature {
     fn feature() -> Feature {
         Feature {
             symbols: Vec::new(),
-            namespace: "ffi".to_string(),
+            namespace: "ffi".into(),
         }
     }
 }

--- a/src/mu/features/nix.rs
+++ b/src/mu/features/nix.rs
@@ -7,7 +7,6 @@ use crate::{
         env::Env,
         exception::{self, Condition, Exception},
         frame::Frame,
-        symbols::CoreFnDef,
         types::Tag,
     },
     features::feature::Feature,
@@ -21,12 +20,6 @@ use crate::{
 };
 use nix::{self};
 
-// env function dispatch table
-lazy_static! {
-    static ref NIX_SYMBOLS: Vec<CoreFnDef> =
-        vec![("uname", 0, <Feature as CoreFunction>::nix_uname)];
-}
-
 pub trait Nix {
     fn feature() -> Feature;
 }
@@ -34,8 +27,8 @@ pub trait Nix {
 impl Nix for Feature {
     fn feature() -> Feature {
         Feature {
-            symbols: NIX_SYMBOLS.to_vec(),
-            namespace: "nix".to_string(),
+            symbols: vec![("uname", 0u16, <Feature as CoreFunction>::nix_uname)],
+            namespace: "nix".into(),
         }
     }
 }

--- a/src/mu/features/prof.rs
+++ b/src/mu/features/prof.rs
@@ -78,7 +78,7 @@ impl CoreFunction for Feature {
         } else if cmd.eq_(&Symbol::keyword("get")) {
             let prof_vec = (*profile_map_ref)
                 .iter()
-                .map(|item| Cons::cons(env, item.0, Fixnum::with_u64(env, item.1)?))
+                .map(|item| Cons::cons(env, item.0, Fixnum::with_u64(env, item.1).unwrap()))
                 .collect::<Vec<Tag>>();
 
             fp.value = Vector::from(prof_vec).evict(env)

--- a/src/mu/features/prof.rs
+++ b/src/mu/features/prof.rs
@@ -25,12 +25,6 @@ use crate::{
 };
 use {futures::executor::block_on, futures_locks::RwLock};
 
-// env function dispatch table
-lazy_static! {
-    static ref PROF_SYMBOLS: Vec<CoreFnDef> =
-        vec![("prof-control", 1, <Feature as CoreFunction>::prof_control)];
-}
-
 pub trait Prof {
     fn feature() -> Feature;
     fn prof_event(_: &Env, _: Tag) -> exception::Result<()>;
@@ -39,8 +33,8 @@ pub trait Prof {
 impl Prof for Feature {
     fn feature() -> Feature {
         Feature {
-            symbols: PROF_SYMBOLS.to_vec(),
-            namespace: "prof".to_string(),
+            symbols: vec![("prof-control", 1, <Feature as CoreFunction>::prof_control)],
+            namespace: "prof".into(),
         }
     }
 
@@ -84,7 +78,7 @@ impl CoreFunction for Feature {
         } else if cmd.eq_(&Symbol::keyword("get")) {
             let prof_vec = (*profile_map_ref)
                 .iter()
-                .map(|item| Cons::cons(env, item.0, Fixnum::with_u64(env, item.1).unwrap()))
+                .map(|item| Cons::cons(env, item.0, Fixnum::with_u64(env, item.1)?))
                 .collect::<Vec<Tag>>();
 
             fp.value = Vector::from(prof_vec).evict(env)

--- a/src/mu/features/std.rs
+++ b/src/mu/features/std.rs
@@ -11,7 +11,6 @@ use crate::{
         env::Env,
         exception::{self, Condition, Exception},
         frame::Frame,
-        symbols::CoreFnDef,
         types::Type,
     },
     features::feature::Feature,
@@ -24,16 +23,6 @@ use crate::{
     },
 };
 
-// env function dispatch table
-lazy_static! {
-    static ref STD_SYMBOLS: Vec<CoreFnDef> = vec![
-        ("command", 2, <Feature as CoreFunction>::std_command),
-        ("env", 0, <Feature as CoreFunction>::std_env),
-        ("exit", 1, <Feature as CoreFunction>::std_exit),
-        ("sleep", 1, <Feature as CoreFunction>::std_sleep),
-    ];
-}
-
 pub trait Std {
     fn feature() -> Feature;
 }
@@ -41,8 +30,13 @@ pub trait Std {
 impl Std for Feature {
     fn feature() -> Feature {
         Feature {
-            symbols: STD_SYMBOLS.to_vec(),
-            namespace: "std".to_string(),
+            symbols: vec![
+                ("command", 2, <Feature as CoreFunction>::std_command),
+                ("env", 0, <Feature as CoreFunction>::std_env),
+                ("exit", 1, <Feature as CoreFunction>::std_exit),
+                ("sleep", 1, <Feature as CoreFunction>::std_sleep),
+            ],
+            namespace: "std".into(),
         }
     }
 }

--- a/src/mu/features/sysinfo.rs
+++ b/src/mu/features/sysinfo.rs
@@ -7,7 +7,6 @@ use crate::{
         env::Env,
         exception::{self, Condition, Exception},
         frame::Frame,
-        symbols::CoreFnDef,
         types::Tag,
     },
     features::feature::Feature,
@@ -20,12 +19,6 @@ use crate::{
 };
 use sysinfo_dot_h::{self};
 
-// env function dispatch table
-lazy_static! {
-    static ref SYSINFO_SYMBOLS: Vec<CoreFnDef> =
-        vec![("sysinfo", 0, <Feature as CoreFunction>::sysinfo_sysinfo),];
-}
-
 pub trait Sysinfo {
     fn feature() -> Feature;
 }
@@ -33,8 +26,8 @@ pub trait Sysinfo {
 impl Sysinfo for Feature {
     fn feature() -> Feature {
         Feature {
-            symbols: SYSINFO_SYMBOLS.to_vec(),
-            namespace: "sysinfo".to_string(),
+            symbols: vec![("sysinfo", 0, <Feature as CoreFunction>::sysinfo_sysinfo)],
+            namespace: "sysinfo".into(),
         }
     }
 }

--- a/src/mu/lib.rs
+++ b/src/mu/lib.rs
@@ -154,7 +154,7 @@ impl Env {
         let env = env_ref.get(&self.0.as_u64()).unwrap();
 
         let stream = StreamBuilder::new()
-            .string(str.to_string())
+            .string(str.into())
             .input()
             .build(env, &LIB)?;
 
@@ -183,7 +183,7 @@ impl Env {
         let env = env_ref.get(&self.0.as_u64()).unwrap();
 
         let str_stream = match StreamBuilder::new()
-            .string("".to_string())
+            .string("".into())
             .output()
             .build(env, &LIB)
         {
@@ -239,8 +239,8 @@ impl Env {
 
         if fs::metadata(file_path).is_ok() {
             let load_form = format!("(mu:open :file :input \"{}\")", file_path);
-            let istream = env.eval(self.read_str(&load_form).unwrap()).unwrap();
-            let eof_value = self.read_str(":eof").unwrap(); // need make_symbol here
+            let istream = env.eval(self.read_str(&load_form)?)?;
+            let eof_value = self.read_str(":eof")?; // need make_symbol here
 
             drop(env_ref);
 
@@ -260,7 +260,7 @@ impl Env {
                 env,
                 Condition::Open,
                 "load",
-                self.read_str(&format!("\"{}\"", file_path)).unwrap(),
+                self.read_str(&format!("\"{}\"", file_path))?,
             ))
         }
     }

--- a/src/mu/streams/operator.rs
+++ b/src/mu/streams/operator.rs
@@ -103,13 +103,10 @@ impl SystemStream {
 impl Core for SystemStream {
     fn open_file(env: &Env, path: &str, is_input: bool) -> exception::Result<Tag> {
         let system_stream = if is_input {
-            SystemStreamBuilder::new()
-                .file(path.to_string())
-                .input()
-                .build()
+            SystemStreamBuilder::new().file(path.into()).input().build()
         } else {
             SystemStreamBuilder::new()
-                .file(path.to_string())
+                .file(path.into())
                 .output()
                 .build()
         };
@@ -128,7 +125,7 @@ impl Core for SystemStream {
                     unch: Tag::nil(),
                 }));
 
-                Ok(DirectTag::to_direct(
+                Ok(DirectTag::to_tag(
                     index as u64,
                     DirectExt::ExtType(ExtType::Stream),
                     DirectType::Ext,
@@ -148,15 +145,15 @@ impl Core for SystemStream {
     fn open_string(env: &Env, contents: &str, dir: StringDirection) -> exception::Result<Tag> {
         let system_stream = match dir {
             StringDirection::Input => SystemStreamBuilder::new()
-                .string(contents.to_string())
+                .string(contents.into())
                 .input()
                 .build(),
             StringDirection::Output => SystemStreamBuilder::new()
-                .string(contents.to_string())
+                .string(contents.into())
                 .output()
                 .build(),
             StringDirection::Bidir => SystemStreamBuilder::new()
-                .string(contents.to_string())
+                .string(contents.into())
                 .bidir()
                 .build(),
         };
@@ -179,7 +176,7 @@ impl Core for SystemStream {
                     unch: Tag::nil(),
                 }));
 
-                Ok(DirectTag::to_direct(
+                Ok(DirectTag::to_tag(
                     index as u64,
                     DirectExt::ExtType(ExtType::Stream),
                     DirectType::Ext,
@@ -220,7 +217,7 @@ impl Core for SystemStream {
                     unch: Tag::nil(),
                 }));
 
-                Ok(DirectTag::to_direct(
+                Ok(DirectTag::to_tag(
                     index as u64,
                     DirectExt::ExtType(ExtType::Stream),
                     DirectType::Ext,

--- a/src/mu/types/char.rs
+++ b/src/mu/types/char.rs
@@ -25,7 +25,7 @@ pub enum Char {
 
 impl From<char> for Tag {
     fn from(ch: char) -> Tag {
-        DirectTag::to_direct(
+        DirectTag::to_tag(
             ch as u64,
             DirectExt::ExtType(ExtType::Char),
             DirectType::Ext,

--- a/src/mu/types/core_stream.rs
+++ b/src/mu/types/core_stream.rs
@@ -41,7 +41,7 @@ pub struct Stream {
 
 impl From<Stream> for Tag {
     fn from(stream: Stream) -> Tag {
-        DirectTag::to_direct(
+        DirectTag::to_tag(
             stream.index as u64,
             DirectExt::ExtType(ExtType::Stream),
             DirectType::Ext,
@@ -50,7 +50,7 @@ impl From<Stream> for Tag {
 }
 
 pub trait Core {
-    fn to_stream_index(_: &Env, _: Tag) -> exception::Result<usize>;
+    fn stream_index(_: &Env, _: Tag) -> exception::Result<usize>;
     fn close(_: &Env, _: Tag);
     fn get_string(_: &Env, _: Tag) -> exception::Result<String>;
     fn is_open(_: &Env, _: Tag) -> bool;
@@ -64,7 +64,7 @@ pub trait Core {
 }
 
 impl Core for Stream {
-    fn to_stream_index(env: &Env, tag: Tag) -> exception::Result<usize> {
+    fn stream_index(env: &Env, tag: Tag) -> exception::Result<usize> {
         match tag {
             Tag::Direct(dtag) => match dtag.dtype() {
                 DirectType::Ext => match dtag.ext().try_into() {
@@ -80,7 +80,7 @@ impl Core for Stream {
     fn view(env: &Env, tag: Tag) -> Tag {
         let streams_ref = block_on(LIB.streams.read());
 
-        match streams_ref.get(Self::to_stream_index(env, tag).unwrap()) {
+        match streams_ref.get(Self::stream_index(env, tag).unwrap()) {
             Some(stream_ref) => {
                 let stream = block_on(stream_ref.read());
                 let vec = vec![
@@ -98,7 +98,7 @@ impl Core for Stream {
     fn is_open(env: &Env, tag: Tag) -> bool {
         let streams_ref = block_on(LIB.streams.read());
 
-        match streams_ref.get(Self::to_stream_index(env, tag).unwrap()) {
+        match streams_ref.get(Self::stream_index(env, tag).unwrap()) {
             Some(stream_ref) => {
                 let stream = block_on(stream_ref.read());
 
@@ -111,7 +111,7 @@ impl Core for Stream {
     fn close(env: &Env, tag: Tag) {
         let streams_ref = block_on(LIB.streams.read());
 
-        match streams_ref.get(Self::to_stream_index(env, tag).unwrap()) {
+        match streams_ref.get(Self::stream_index(env, tag).unwrap()) {
             Some(stream_ref) => {
                 let stream = block_on(stream_ref.read());
 
@@ -128,7 +128,7 @@ impl Core for Stream {
 
         let streams_ref = block_on(LIB.streams.read());
 
-        match streams_ref.get(Self::to_stream_index(env, tag).unwrap()) {
+        match streams_ref.get(Self::stream_index(env, tag).unwrap()) {
             Some(stream_ref) => {
                 let stream = block_on(stream_ref.read());
 
@@ -143,7 +143,7 @@ impl Core for Stream {
             Type::Stream => {
                 let streams_ref = block_on(LIB.streams.read());
 
-                match streams_ref.get(Self::to_stream_index(env, tag).unwrap()) {
+                match streams_ref.get(Self::stream_index(env, tag).unwrap()) {
                     Some(stream_ref) => {
                         let stream = block_on(stream_ref.read());
 
@@ -191,7 +191,7 @@ impl Core for Stream {
 
         let streams_ref = block_on(LIB.streams.read());
 
-        match streams_ref.get(Self::to_stream_index(env, tag).unwrap()) {
+        match streams_ref.get(Self::stream_index(env, tag).unwrap()) {
             Some(stream_ref) => {
                 let mut stream = block_on(stream_ref.write());
 
@@ -224,7 +224,7 @@ impl Core for Stream {
 
         let streams_ref = block_on(LIB.streams.read());
 
-        match streams_ref.get(Self::to_stream_index(env, tag).unwrap()) {
+        match streams_ref.get(Self::stream_index(env, tag).unwrap()) {
             Some(stream_ref) => {
                 let mut stream = block_on(stream_ref.write());
 
@@ -259,7 +259,7 @@ impl Core for Stream {
 
         let streams_ref = block_on(LIB.streams.read());
 
-        match streams_ref.get(Self::to_stream_index(env, tag).unwrap()) {
+        match streams_ref.get(Self::stream_index(env, tag).unwrap()) {
             Some(stream_ref) => {
                 let mut stream = block_on(stream_ref.write());
 
@@ -296,7 +296,7 @@ impl Core for Stream {
 
         let streams_ref = block_on(LIB.streams.read());
 
-        match streams_ref.get(Self::to_stream_index(env, tag).unwrap()) {
+        match streams_ref.get(Self::stream_index(env, tag).unwrap()) {
             Some(stream_ref) => {
                 let stream = block_on(stream_ref.read());
 
@@ -320,7 +320,7 @@ impl Core for Stream {
 
         let streams_ref = block_on(LIB.streams.read());
 
-        match streams_ref.get(Self::to_stream_index(env, tag).unwrap()) {
+        match streams_ref.get(Self::stream_index(env, tag).unwrap()) {
             Some(stream_ref) => {
                 let stream = block_on(stream_ref.read());
 

--- a/src/mu/types/fixnum.rs
+++ b/src/mu/types/fixnum.rs
@@ -29,7 +29,7 @@ pub enum Fixnum {
 // tag from u32
 impl From<u32> for Tag {
     fn from(fx: u32) -> Tag {
-        DirectTag::to_direct(
+        DirectTag::to_tag(
             ((fx as i64) & (2_i64.pow(56) - 1)) as u64,
             DirectExt::ExtType(ExtType::Fixnum),
             DirectType::Ext,
@@ -40,7 +40,7 @@ impl From<u32> for Tag {
 // tag from u16
 impl From<u16> for Tag {
     fn from(fx: u16) -> Tag {
-        DirectTag::to_direct(
+        DirectTag::to_tag(
             ((fx as i64) & (2_i64.pow(56) - 1)) as u64,
             DirectExt::ExtType(ExtType::Fixnum),
             DirectType::Ext,
@@ -51,7 +51,7 @@ impl From<u16> for Tag {
 // tag from u8
 impl From<u8> for Tag {
     fn from(fx: u8) -> Tag {
-        DirectTag::to_direct(
+        DirectTag::to_tag(
             ((fx as i64) & (2_i64.pow(56) - 1)) as u64,
             DirectExt::ExtType(ExtType::Fixnum),
             DirectType::Ext,
@@ -105,7 +105,7 @@ impl Core for Fixnum {
                     panic!()
                 }
 
-                DirectTag::to_direct(
+                DirectTag::to_tag(
                     (i64_ & (2_i64.pow(56) - 1)) as u64,
                     DirectExt::ExtType(ExtType::Fixnum),
                     DirectType::Ext,
@@ -119,7 +119,7 @@ impl Core for Fixnum {
             panic!()
         }
 
-        DirectTag::to_direct(
+        DirectTag::to_tag(
             (fx & (2_i64.pow(56) - 1)) as u64,
             DirectExt::ExtType(ExtType::Fixnum),
             DirectType::Ext,
@@ -135,7 +135,7 @@ impl Core for Fixnum {
             return Err(Exception::new(env, Condition::Over, "fixnum", Tag::nil()));
         }
 
-        Ok(DirectTag::to_direct(
+        Ok(DirectTag::to_tag(
             (fx & (2_i64.pow(56) - 1)) as u64,
             DirectExt::ExtType(ExtType::Fixnum),
             DirectType::Ext,
@@ -150,7 +150,7 @@ impl Core for Fixnum {
                     return Err(Exception::new(env, Condition::Over, "fixnum", Tag::nil()));
                 }
 
-                Ok(DirectTag::to_direct(
+                Ok(DirectTag::to_tag(
                     ((fx as i64) & (2_i64.pow(56) - 1)) as u64,
                     DirectExt::ExtType(ExtType::Fixnum),
                     DirectType::Ext,

--- a/src/mu/types/float.rs
+++ b/src/mu/types/float.rs
@@ -31,7 +31,7 @@ pub enum Float {
 impl From<f32> for Tag {
     fn from(fl: f32) -> Tag {
         let bytes = fl.to_le_bytes();
-        DirectTag::to_direct(
+        DirectTag::to_tag(
             u32::from_le_bytes(bytes) as u64,
             DirectExt::ExtType(ExtType::Float),
             DirectType::Ext,

--- a/src/mu/types/function.rs
+++ b/src/mu/types/function.rs
@@ -141,16 +141,14 @@ impl Core for Function {
                 let form = Function::form(env, func);
 
                 let desc = match form.type_of() {
-                    Type::Cons | Type::Null => {
-                        ("lambda".to_string(), format!("{:x}", form.as_u64()))
-                    }
+                    Type::Cons | Type::Null => ("lambda".into(), format!("{:x}", form.as_u64())),
                     Type::Vector => {
                         let ns = Vector::ref_(env, form, 0).unwrap();
                         let name = Vector::ref_(env, form, 1).unwrap();
 
                         (
                             Namespace::name(env, ns).unwrap(),
-                            Vector::as_string(env, name).to_string(),
+                            Vector::as_string(env, name),
                         )
                     }
                     _ => panic!(),

--- a/src/mu/types/namespace.rs
+++ b/src/mu/types/namespace.rs
@@ -46,7 +46,7 @@ impl Namespace {
             ));
         }
 
-        let ns = DirectTag::to_direct(
+        let ns = DirectTag::to_tag(
             len as u64,
             DirectExt::ExtType(ExtType::Namespace),
             DirectType::Ext,
@@ -54,7 +54,7 @@ impl Namespace {
 
         ns_ref.push((
             ns,
-            name.to_string(),
+            name.into(),
             Namespace::Dynamic(RwLock::new(HashMap::<String, Tag>::new())),
         ));
 
@@ -80,13 +80,13 @@ impl Namespace {
             ));
         }
 
-        let ns = DirectTag::to_direct(
+        let ns = DirectTag::to_tag(
             len as u64,
             DirectExt::ExtType(ExtType::Namespace),
             DirectType::Ext,
         );
 
-        ns_ref.push((ns, name.to_string(), Namespace::Static(ns_map)));
+        ns_ref.push((ns, name.into(), Namespace::Static(ns_map)));
 
         Ok(ns)
     }
@@ -157,9 +157,9 @@ impl Namespace {
         ) {
             Some(tag) => {
                 if tag.is_empty() {
-                    Some("".to_string())
+                    Some("".into())
                 } else {
-                    Some(tag.to_string())
+                    Some(tag.into())
                 }
             }
             None => None,

--- a/src/mu/types/stream.rs
+++ b/src/mu/types/stream.rs
@@ -231,7 +231,7 @@ impl CoreFunction for Stream {
 
         let streams_ref = block_on(LIB.streams.read());
 
-        fp.value = match streams_ref.get(Self::to_stream_index(env, tag).unwrap()) {
+        fp.value = match streams_ref.get(Self::stream_index(env, tag)?) {
             Some(stream_ref) => {
                 if Self::is_open(env, tag) {
                     let stream = block_on(stream_ref.read());
@@ -335,7 +335,7 @@ mod tests {
     #[test]
     fn stream_builder() {
         let stream = SystemStreamBuilder::new()
-            .string("hello".to_string())
+            .string("hello".into())
             .input()
             .build();
 

--- a/src/mu/types/symbol.rs
+++ b/src/mu/types/symbol.rs
@@ -41,8 +41,7 @@ pub struct SymbolImage {
 }
 
 lazy_static! {
-    pub static ref UNBOUND: Tag =
-        DirectTag::to_direct(0, DirectExt::Length(0), DirectType::Keyword);
+    pub static ref UNBOUND: Tag = DirectTag::to_tag(0, DirectExt::Length(0), DirectType::Keyword);
 }
 
 impl Symbol {
@@ -121,7 +120,7 @@ impl Symbol {
     pub fn name(env: &Env, symbol: Tag) -> Tag {
         match symbol.type_of() {
             Type::Null | Type::Keyword => match symbol {
-                Tag::Direct(dir) => DirectTag::to_direct(
+                Tag::Direct(dir) => DirectTag::to_tag(
                     dir.data(),
                     DirectExt::Length(dir.ext() as usize),
                     DirectType::String,
@@ -144,7 +143,7 @@ impl Symbol {
     pub fn ref_name(gc: &mut Gc, symbol: Tag) -> Tag {
         match symbol.type_of() {
             Type::Null | Type::Keyword => match symbol {
-                Tag::Direct(dir) => DirectTag::to_direct(
+                Tag::Direct(dir) => DirectTag::to_tag(
                     dir.data(),
                     DirectExt::Length(dir.ext() as usize),
                     DirectType::String,
@@ -256,7 +255,7 @@ impl Core for Symbol {
         for (src, dst) in str.iter().zip(data.iter_mut()) {
             *dst = *src
         }
-        DirectTag::to_direct(
+        DirectTag::to_tag(
             u64::from_le_bytes(data),
             DirectExt::Length(len),
             DirectType::Keyword,
@@ -289,8 +288,8 @@ impl Core for Symbol {
             }
             Some(_) => {
                 let sym: Vec<&str> = token.split(':').collect();
-                let ns = sym[0].to_string();
-                let name = sym[1].to_string();
+                let ns: String = sym[0].into();
+                let name = sym[1].into();
 
                 if sym.len() != 2 {
                     return Err(Exception::new(

--- a/src/mu/types/vector.rs
+++ b/src/mu/types/vector.rs
@@ -241,7 +241,7 @@ impl<'a> Core<'a> for Vector {
                 Tag::Direct(dir) => match dir.dtype() {
                     DirectType::String => str::from_utf8(&dir.data().to_le_bytes()).unwrap()
                         [..dir.ext() as usize]
-                        .to_string(),
+                        .into(),
                     _ => panic!(),
                 },
                 Tag::Indirect(image) => {
@@ -258,7 +258,7 @@ impl<'a> Core<'a> for Vector {
                             .unwrap(),
                     )
                     .unwrap()
-                    .to_string()
+                    .into()
                 }
             },
             _ => panic!(),

--- a/src/mu/types/vector_image.rs
+++ b/src/mu/types/vector_image.rs
@@ -70,7 +70,7 @@ impl From<&str> for Vector {
                 length: Fixnum::with_or_panic(str.len()),
             };
 
-            Vector::Indirect(image, VectorImageType::Char(str.to_string()))
+            Vector::Indirect(image, VectorImageType::Char(str.into()))
         } else {
             let mut data: [u8; 8] = 0_u64.to_le_bytes();
 
@@ -78,7 +78,7 @@ impl From<&str> for Vector {
                 *dst = *src
             }
 
-            Vector::Direct(DirectTag::to_direct(
+            Vector::Direct(DirectTag::to_tag(
                 u64::from_le_bytes(data),
                 DirectExt::Length(len),
                 DirectType::String,
@@ -105,7 +105,7 @@ impl From<&[u8]> for Vector {
                 *dst = *src
             }
 
-            Vector::Direct(DirectTag::to_direct(
+            Vector::Direct(DirectTag::to_tag(
                 u64::from_le_bytes(data),
                 DirectExt::Length(len),
                 DirectType::ByteVec,
@@ -127,7 +127,7 @@ impl From<Vec<i64>> for Vector {
             length: Fixnum::with_or_panic(vec.len()),
         };
 
-        Vector::Indirect(image, VectorImageType::Fixnum(vec.to_vec()))
+        Vector::Indirect(image, VectorImageType::Fixnum(vec.clone()))
     }
 }
 
@@ -159,7 +159,7 @@ impl From<Vec<f32>> for Vector {
             length: Fixnum::with_or_panic(vec.len()),
         };
 
-        Vector::Indirect(image, VectorImageType::Float(vec.to_vec()))
+        Vector::Indirect(image, VectorImageType::Float(vec.clone()))
     }
 }
 


### PR DESCRIPTION
use clone where clearer, eliminate some unnecessary vector copies, better naming

docs: no change
tests: no change
src: rewrite some to_vec() calls to clones, eliminate feature lazy_statics, make some to_strings intos.