### PR TITLE
#559 - mu: break up vector monolith

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -44,9 +44,10 @@ dist:
 
 	@install -D -t $(BASE)/modules/codegen $(SRC)/modules/codegen/*.l
 	@install -D -t $(BASE)/modules/common $(SRC)/modules/common/*.l
+	@install -D -t $(BASE)/modules/describe $(SRC)/modules/describe/*.l
 	@install -D -t $(BASE)/modules/metrics $(SRC)/modules/metrics/*.l
-	@install -D -t $(BASE)/modules/repl $(SRC)/modules/repl/*.l
 	@install -D -t $(BASE)/modules/prelude $(SRC)/modules/prelude/*.l
+	@install -D -t $(BASE)/modules/repl $(SRC)/modules/repl/*.l
 
 	@make -f dist.mk dist
 

--- a/src/modules/describe/describe.l
+++ b/src/modules/describe/describe.l
@@ -1,0 +1,149 @@
+;;;  SPDX-FileCopyrightText: Copyright 2023 James M. Putnam (putnamjm.design@gmail.com)
+;;;  SPDX-License-Identifier: MIT
+
+;;;
+;;; describe
+;;;
+(mu:intern mu:%null-ns% "describe" (mu:make-namespace "describe"))
+(mu:intern describe "+version+" "0.0.1")
+
+(core:provide "describe" ())
+
+;;;
+;;; describe
+;;;
+(mu:intern describe "%describe-fn"
+   (:lambda (fn)
+     (:if (core:%closure-p fn)
+          ((:lambda (lambda arity fn env)
+             (core:eprint "" "%describe-fn:core")
+             (core:eprint lambda "    lambda")
+             (core:eprint arity "    arity")
+             (core:eprint fn "    fn")
+             (core:eprint env "    env"))
+           (core:%fn-prop :lambda fn)
+           (core:%fn-prop :arity fn)
+           (core:%fn-prop :fn fn)
+           (core:%fn-prop :env fn))
+          (core:eprint (mu:view fn) "%describe-fn:mu-fn"))))
+
+(mu:intern describe "%describe-function"
+   (:lambda (fn stream)
+      ((:lambda (view)
+          (core:%format stream
+            "function: (~A bytes) :func ~A~%    name:  [~A]~%    arity: ~A~%    body:  ~A~%"
+            `(,(mu:heap-size fn)
+              ,(prelude:type-of fn)
+              ,(mu:svref view 2)
+              ,(mu:svref view 0)
+              ,(mu:svref view 1))))
+       (mu:view fn))))
+
+(mu:intern describe "%describe-prelude-type"
+   (:lambda (value stream)
+      (core:%format stream
+       "prelude-type: (~A bytes) :<type> ~A~%    type:  ~A~%    props: ~A~%"
+       `(,(mu:heap-size value)
+         ,(prelude:type-of value)
+         ,(mu:struct-ref (mu:st-vec value) 0)
+         ,(mu:struct-ref (mu:st-vec value) 0)))))
+
+(mu:intern describe "%describe-struct"
+   (:lambda (struct stream)
+      (core:%format stream
+       "struct: (~A bytes) :struct ~A~%    type:  ~A~%    props: ~A~%"
+       `(,(mu:heap-size struct)
+         ,(prelude:type-of struct)
+         ,(mu:st-type struct)
+         ,(mu:st-vec struct)))))
+
+(mu:intern describe "%describe-symbol"
+   (:lambda (symbol stream)
+      (:if (core:null symbol)
+           (core:%format stream
+            "symbol: (~A bytes) :null null~%    ns:    ()~%    name:  :nil~%    value: ()~%"
+            `(,(mu:heap-size symbol)))
+           (:if (core:keywordp symbol)
+                (core:%format stream
+                 "symbol: (~A bytes) :symbol keyword~%    ns:    ()~%    name:  ~A~%    value: ~A~%"
+                 `(,(mu:heap-size symbol) ,(mu:symbol-name symbol) ,(mu:symbol-value symbol)))
+                (:if (mu:boundp symbol)
+                     ((:lambda (view)
+                         (core:%format stream
+                          "symbol: (~A bytes) :symbol symbol~%    ns:    ~A~%    name:  ~A~%    value: ~A~%"
+                          `(,(mu:heap-size symbol)
+                            ,(mu:struct-ref view 0)
+                            ,(mu:struct-ref view 1)
+                            ,(mu:struct-ref view 2))))
+                      (mu:view symbol))
+                     ((:lambda (view)
+                         (core:%format stream
+                          "symbol: (~A bytes) :symbol symbol~%    ns:      ~A~%    name:    ~A~%    unbound: :t~%"
+                          `(,(mu:heap-size symbol)
+                            ,(mu:struct-ref view 0)
+                            ,(mu:struct-ref view 1)
+                            ,(mu:struct-ref view 2))))
+                      (mu:view symbol)))))))
+
+(mu:intern describe "%describe-fixnum"
+   (:lambda (fx stream)
+      (core:%format stream "fixnum: (~A bytes) :fixnum ~A~%    format: 56b signed integer immediate~%    value:  ~A~%"
+        `(,(mu:heap-size fx) ,(describe:type-of fx) ,fx))))
+
+(mu:intern describe "%describe-char"
+   (:lambda (ch stream)
+      (core:%format stream "char: (~A bytes) :char ~A~%    format: 8b ASCII character immediate~%    value:  ~A~%"
+        `(,(mu:heap-size ch) ,(describe:type-of ch) ,ch))))
+
+(mu:intern describe "%describe-float"
+   (:lambda (fl stream)
+      (core:%format stream
+       "float: :float ~A~%    format: 32b IEEE single float immediate~%    value:  ~A~%"
+       `(,(describe:type-of fl) ,fl))))
+
+(mu:intern describe "%describe-string"
+   (:lambda (str stream)
+      (core:%format stream
+       "string: (~A bytes) :vector string~%    format: unsigned 8b character vector~%    length: ~A~%    value:  ~A~%"
+       `(,(mu:heap-size str) ,(mu:struct-len str) ,str))))
+
+(mu:intern describe "%describe-vector"
+   (:lambda (vec stream)
+      (core:%format stream
+       "vector: (~A bytes) :vector ~A~%    format: ~A~%    length: ~A~%    elements:  ~A~%"
+       `(,(mu:heap-size vec) ,(describe:type-of vec) ,(mu:struct-type vec) ,(mu:struct-type vec) ,vec))))
+
+(mu:intern describe "%describe-cons"
+   (:lambda (cons stream)
+      (:if (describe:dotted-pair-p cons)
+           (core:%format stream
+            "dotted pair: (~A bytes) :cons ~A~%    value:  ~A~%"
+            `(,(mu:heap-size cons) ,(describe:type-of cons) ,cons))
+           (core:%format stream
+            "cons: (~A bytes) :cons ~A~%    length: ~A~%    value:  ~A~%"
+            `(,(mu:heap-size cons) ,(describe:type-of cons) ,(mu:length cons) ,cons)))))
+
+(mu:intern describe "describe"
+   (:lambda (value stream)
+      (mu:fix
+       (:lambda (list)
+          (:if (core:null list)
+               ()
+               ((:lambda (predicate fn)
+                   (:if (mu:apply predicate `(,value))
+                        ((:lambda ()
+                            (mu:apply fn `(,value ,stream))
+                            ()))
+                        (mu:cdr list)))
+               (mu:car (mu:car list))
+               (mu:cdr (mu:car list)))))
+       `(,(mu:cons core:functionp describe:%describe-function)
+         ,(mu:cons core:charp describe:%describe-char)
+         ,(mu:cons core:%core-type-p describe:%describe-describe-type)
+         ,(mu:cons core:structp describe:%describe-struct)
+         ,(mu:cons core:symbolp describe:%describe-symbol)
+         ,(mu:cons core:fixnump describe:%describe-fixnum)
+         ,(mu:cons core:floatp describe:%describe-float)
+         ,(mu:cons core:stringp describe:%describe-string)
+         ,(mu:cons core:vectorp describe:%describe-vector)
+          ,(mu:cons core:consp describe:%describe-cons)))))

--- a/src/mu/core/dynamic.rs
+++ b/src/mu/core/dynamic.rs
@@ -17,8 +17,8 @@ use crate::{
     types::{
         cons::{Cons, Core as _},
         vector::Vector,
-        vector_image::Core as _,
     },
+    vectors::core::Core as _,
 };
 
 use futures::executor::block_on;

--- a/src/mu/core/env.rs
+++ b/src/mu/core/env.rs
@@ -1,13 +1,20 @@
 //  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
-//! env environment
-//!    Env
+//! env structure
+#[allow(unused_imports)]
 use {
     crate::{
-        core::{config::Config, frame::Frame, lib::Lib, types::Tag},
+        core::{
+            config::Config,
+            frame::Frame,
+            lib::Lib,
+            nursery::{Core as _, Nursery},
+            types::{Tag, TypeImage},
+        },
         images::bump_allocator::BumpAllocator,
-        types::{namespace::Namespace, vector::VecCacheMap},
+        types::namespace::Namespace,
+        vectors::cache::VecCacheMap,
         LIB,
     },
     cpu_time::ProcessTime,
@@ -24,6 +31,7 @@ pub struct Env {
 
     // heap
     pub heap: RwLock<BumpAllocator>,
+    pub nursery: RwLock<Nursery>,
     pub gc_root: RwLock<Vec<Tag>>,
     pub vector_map: RwLock<VecCacheMap>,
 
@@ -52,6 +60,7 @@ pub struct Env {
 impl Env {
     pub fn new(config: Config, _image: Option<Vec<u8>>) -> Self {
         let heap = BumpAllocator::new(config.npages, Tag::NTYPES);
+        let nursery = Nursery::new();
 
         let mut env = Env {
             config,
@@ -63,6 +72,7 @@ impl Env {
             lexical: RwLock::new(HashMap::new()),
             ns_map: RwLock::new(Vec::new()),
             null_ns: Tag::nil(),
+            nursery: RwLock::new(nursery),
             #[cfg(feature = "prof")]
             prof: RwLock::new(Vec::new()),
             #[cfg(feature = "prof")]

--- a/src/mu/core/future.rs
+++ b/src/mu/core/future.rs
@@ -20,8 +20,8 @@ use crate::{
         struct_::{Core as _, Struct},
         symbol::{Core as _, Symbol},
         vector::{Core as _, Vector},
-        vector_image::Core as _,
     },
+    vectors::core::Core as _,
 };
 
 #[allow(unused_imports)]

--- a/src/mu/core/gc.rs
+++ b/src/mu/core/gc.rs
@@ -71,6 +71,7 @@ impl Gc {
 
                 marked
             }
+            Tag::Nursery(_) => panic!(),
         }
     }
 

--- a/src/mu/core/heap.rs
+++ b/src/mu/core/heap.rs
@@ -12,8 +12,7 @@ use crate::{
         indirect::{self, IndirectTag},
         types::{Tag, Type},
     },
-    images::allocator::AllocTypeInfo,
-    images::bump_allocator::BumpAllocator,
+    images::{allocator::AllocTypeInfo, bump_allocator::BumpAllocator},
     types::{
         cons::{Cons, Core as _},
         fixnum::{Core as _, Fixnum},
@@ -21,8 +20,8 @@ use crate::{
         struct_::{Core as _, Struct},
         symbol::{Core as _, Symbol},
         vector::Vector,
-        vector_image::Core as _,
     },
+    vectors::core::Core as _,
 };
 
 use futures::executor::block_on;

--- a/src/mu/core/lib.rs
+++ b/src/mu/core/lib.rs
@@ -19,8 +19,8 @@ use {
             stream::Stream,
             symbol::{Core as _, Symbol},
             vector::Vector,
-            vector_image::Core as _,
         },
+        vectors::core::Core as _,
     },
     std::collections::HashMap,
 };

--- a/src/mu/core/mod.rs
+++ b/src/mu/core/mod.rs
@@ -15,6 +15,7 @@ pub mod gc;
 pub mod heap;
 pub mod indirect;
 pub mod lib;
+pub mod nursery;
 pub mod quasi;
 pub mod reader;
 pub mod readtable;

--- a/src/mu/core/nursery.rs
+++ b/src/mu/core/nursery.rs
@@ -1,0 +1,96 @@
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-License-Identifier: MIT
+
+//! env nursery interface
+#[allow(unused_imports)]
+use crate::{
+    core::{
+        direct::DirectTag,
+        env::Env,
+        exception,
+        frame::Frame,
+        indirect::{self, IndirectTag},
+        types::{ImageId, Tag, Type, TypeImage},
+    },
+    types::{
+        cons::{Cons, Core as _},
+        fixnum::{Core as _, Fixnum},
+        function::{Core as _, Function},
+        struct_::{Core as _, Struct},
+        symbol::{Core as _, Symbol},
+        vector::Vector,
+    },
+    vectors::core::Core as _,
+};
+
+use std::collections::HashMap;
+
+// locking protocols
+use futures::executor::block_on;
+use futures_locks::RwLock;
+
+impl Default for Nursery {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone)]
+pub struct Nursery {
+    id: RwLock<ImageId>,
+    map: RwLock<HashMap<ImageId, TypeImage>>,
+}
+
+impl Nursery {
+    pub fn new() -> Self {
+        Nursery {
+            id: RwLock::new(0),
+            map: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+pub trait Core {
+    fn nursery_info(&self) -> usize;
+    fn nursery_ref(&self, _: &ImageId) -> TypeImage;
+    fn nursery_cache_image(&self, _: TypeImage);
+    fn nursery_uncache_image(&self, _: &ImageId);
+}
+
+impl Core for Nursery {
+    fn nursery_info(&self) -> usize {
+        let map_ref = block_on(self.map.read());
+
+        (*map_ref).len()
+    }
+
+    fn nursery_ref(&self, id: &ImageId) -> TypeImage {
+        let map_ref = block_on(self.map.read());
+
+        map_ref[id].clone()
+    }
+
+    fn nursery_cache_image(&self, image: TypeImage) {
+        let mut map_ref = block_on(self.map.write());
+        let mut nursery_id = block_on(self.id.write());
+
+        let id = *nursery_id;
+
+        *nursery_id = id + 1;
+        map_ref.insert(id, image).unwrap();
+    }
+
+    fn nursery_uncache_image(&self, id: &ImageId) {
+        let mut map_ref = block_on(self.map.write());
+
+        map_ref.remove(id).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn env() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/src/mu/core/reader.rs
+++ b/src/mu/core/reader.rs
@@ -18,9 +18,9 @@ use crate::{
         stream::{Core as _, Stream},
         struct_::{Core as _, Struct},
         symbol::{Core as _, Symbol},
-        vector::{Core as _, Vector},
-        vector_image::Core as _,
+        vector::Vector,
     },
+    vectors::{core::Core as _, read::Core as _},
 };
 
 //

--- a/src/mu/core/types.rs
+++ b/src/mu/core/types.rs
@@ -24,8 +24,8 @@ use {
             struct_::{Core as _, Struct},
             symbol::{Core as _, Symbol},
             vector::{Core as _, Vector},
-            vector_image::Core as _,
         },
+        vectors::core::Core as _,
     },
     num_enum::TryFromPrimitive,
     std::{convert::From, fmt},
@@ -34,10 +34,27 @@ use {
 use futures::executor::block_on;
 
 // tag storage classes
+pub type ImageId = usize;
+
+#[derive(Clone)]
+pub enum TypeImage {
+    Char(DirectTag),
+    Cons(Cons),
+    Fixnum(DirectTag),
+    Float(DirectTag),
+    Function(Function),
+    Keyword(DirectTag),
+    Namespace(DirectTag),
+    Struct(Struct),
+    Symbol(Symbol),
+    Vector(Vector),
+}
+
 #[derive(Copy, Clone)]
 pub enum Tag {
     Direct(DirectTag),
     Indirect(IndirectTag),
+    Nursery(ImageId),
 }
 
 // types
@@ -108,6 +125,7 @@ impl fmt::Display for Tag {
         match self {
             Tag::Direct(direct) => write!(f, "direct: type {:?}", direct.dtype() as u8),
             Tag::Indirect(indirect) => write!(f, "indirect: type {:?}", indirect.tag()),
+            Tag::Nursery(_) => panic!(),
         }
     }
 }
@@ -135,6 +153,7 @@ impl Tag {
                     None => panic!(),
                 }
             }
+            Tag::Nursery(_) => panic!(),
         }
     }
 
@@ -142,6 +161,7 @@ impl Tag {
         match self {
             Tag::Direct(tag) => tag.into_bytes(),
             Tag::Indirect(tag) => tag.into_bytes(),
+            Tag::Nursery(_) => panic!(),
         }
     }
 
@@ -204,6 +224,7 @@ impl Tag {
                     TagType::Vector => Type::Vector,
                     _ => panic!("indirect type botch {:x}", self.as_u64()),
                 },
+                Tag::Nursery(_) => panic!(),
             }
         }
     }

--- a/src/mu/features/nix.rs
+++ b/src/mu/features/nix.rs
@@ -15,8 +15,8 @@ use crate::{
         struct_::{Core as _, Struct},
         symbol::{Core as _, Symbol},
         vector::Vector,
-        vector_image::Core as _,
     },
+    vectors::core::Core as _,
 };
 use nix::{self};
 

--- a/src/mu/features/prof.rs
+++ b/src/mu/features/prof.rs
@@ -20,8 +20,8 @@ use crate::{
         struct_::{Core as _, Struct},
         symbol::{Core as _, Symbol},
         vector::{Core as _, Vector},
-        vector_image::Core as _,
     },
+    vectors::image::Core as _,
 };
 use {futures::executor::block_on, futures_locks::RwLock};
 

--- a/src/mu/features/prof.rs
+++ b/src/mu/features/prof.rs
@@ -21,7 +21,7 @@ use crate::{
         symbol::{Core as _, Symbol},
         vector::{Core as _, Vector},
     },
-    vectors::image::Core as _,
+    vectors::core::Core as _,
 };
 use {futures::executor::block_on, futures_locks::RwLock};
 

--- a/src/mu/features/std.rs
+++ b/src/mu/features/std.rs
@@ -19,8 +19,8 @@ use crate::{
         fixnum::{Core as _, Fixnum},
         float::Float,
         vector::{Core as _, Vector},
-        vector_image::Core as _,
     },
+    vectors::core::Core as _,
 };
 
 pub trait Std {

--- a/src/mu/features/sysinfo.rs
+++ b/src/mu/features/sysinfo.rs
@@ -14,8 +14,8 @@ use crate::{
         cons::{Cons, Core as _},
         fixnum::{Core as _, Fixnum},
         vector::Vector,
-        vector_image::Core as _,
     },
+    vectors::core::Core as _,
 };
 use sysinfo_dot_h::{self};
 

--- a/src/mu/images/allocator.rs
+++ b/src/mu/images/allocator.rs
@@ -78,6 +78,7 @@ impl Allocator for Heap {
         match tag {
             Tag::Direct(_) => None,
             Tag::Indirect(indirect) => (self.allocator).image_info(indirect.image_id() as usize),
+            Tag::Nursery(_) => panic!(),
         }
     }
 
@@ -85,6 +86,7 @@ impl Allocator for Heap {
         match tag {
             Tag::Direct(_) => None,
             Tag::Indirect(_) => self.image_info(tag).map(|info| info.mark()),
+            Tag::Nursery(_) => panic!(),
         }
     }
 
@@ -104,6 +106,7 @@ impl Allocator for Heap {
                     Some(mark)
                 }
             },
+            Tag::Nursery(_) => panic!(),
         }
     }
 

--- a/src/mu/lib.rs
+++ b/src/mu/lib.rs
@@ -22,7 +22,7 @@
 //! - symbol namespaces
 //!
 //! library data types:
-//!    56 bit immediate fixnums
+//!    56 bit immediate signed fixnums
 //!    Lisp-1 namespaced symbols
 //!    character, string, and byte streams
 //!    immediate ASCII characters
@@ -54,6 +54,7 @@ mod images;
 mod streams;
 mod system;
 mod types;
+mod vectors;
 
 use futures::executor::block_on;
 use {

--- a/src/mu/streams/read.rs
+++ b/src/mu/streams/read.rs
@@ -18,8 +18,9 @@ use crate::{
     types::{
         cons::{Cons, Core as _},
         stream::{Core as _, Stream},
-        vector::{Core as _, Vector},
+        vector::Vector,
     },
+    vectors::read::Core as _,
 };
 
 pub trait Core {

--- a/src/mu/streams/write.rs
+++ b/src/mu/streams/write.rs
@@ -21,8 +21,8 @@ use crate::{
         struct_::{Core as _, Struct},
         symbol::{Core as _, Symbol},
         vector::Vector,
-        vector_image::Core as _,
     },
+    vectors::core::Core as _,
 };
 
 pub trait Core {

--- a/src/mu/types/char.rs
+++ b/src/mu/types/char.rs
@@ -13,8 +13,8 @@ use crate::{
     types::{
         stream::{Core as _, Stream},
         vector::Vector,
-        vector_image::Core as _,
     },
+    vectors::core::Core as _,
 };
 
 #[derive(Copy, Clone)]

--- a/src/mu/types/cons.rs
+++ b/src/mu/types/cons.rs
@@ -19,8 +19,8 @@ use crate::{
         fixnum::{Core as _, Fixnum},
         symbol::Symbol,
         vector::Vector,
-        vector_image::Core as _,
     },
+    vectors::core::Core as _,
 };
 
 use futures::executor::block_on;
@@ -74,6 +74,7 @@ impl Cons {
             Type::Cons => match cons {
                 Tag::Direct(_) => DirectTag::car(cons),
                 Tag::Indirect(_) => Self::gc_ref_image(&mut gc.lock, cons).car,
+                Tag::Nursery(_) => panic!(),
             },
             _ => panic!(),
         }
@@ -85,6 +86,7 @@ impl Cons {
             Type::Cons => match cons {
                 Tag::Indirect(_) => Self::gc_ref_image(&mut gc.lock, cons).cdr,
                 Tag::Direct(_) => DirectTag::cdr(cons),
+                Tag::Nursery(_) => panic!(),
             },
             _ => panic!(),
         }
@@ -109,6 +111,7 @@ impl Cons {
                     gc.mark(env, cdr)
                 }
             }
+            Tag::Nursery(_) => panic!(),
         }
     }
 }
@@ -141,6 +144,7 @@ impl Core for Cons {
             Type::Cons => match cons {
                 Tag::Direct(_) => DirectTag::car(cons),
                 Tag::Indirect(_) => Self::to_image(env, cons).car,
+                Tag::Nursery(_) => panic!(),
             },
             _ => panic!(),
         }
@@ -152,6 +156,7 @@ impl Core for Cons {
             Type::Cons => match cons {
                 Tag::Indirect(_) => Self::to_image(env, cons).cdr,
                 Tag::Direct(_) => DirectTag::cdr(cons),
+                Tag::Nursery(_) => panic!(),
             },
             _ => panic!(),
         }
@@ -201,6 +206,7 @@ impl Core for Cons {
                 _ => panic!(),
             },
             Tag::Indirect(_) => std::mem::size_of::<Cons>(),
+            Tag::Nursery(_) => panic!(),
         }
     }
 

--- a/src/mu/types/fixnum.rs
+++ b/src/mu/types/fixnum.rs
@@ -16,8 +16,8 @@ use crate::{
         cons::{Cons, Core as _},
         symbol::{Core as _, Symbol},
         vector::Vector,
-        vector_image::Core as _,
     },
+    vectors::core::Core as _,
 };
 
 #[derive(Copy, Clone)]

--- a/src/mu/types/float.rs
+++ b/src/mu/types/float.rs
@@ -16,8 +16,8 @@ use {
         types::{
             symbol::{Core as _, Symbol},
             vector::Vector,
-            vector_image::Core as _,
         },
+        vectors::core::Core as _,
     },
     std::ops::{Add, Div, Mul, Sub},
 };

--- a/src/mu/types/function.rs
+++ b/src/mu/types/function.rs
@@ -14,9 +14,10 @@ use crate::{
     types::{
         fixnum::Fixnum,
         namespace::Namespace,
+        symbol::{Core as _, Symbol},
         vector::{Core as _, Vector},
-        vector_image::Core as _,
     },
+    vectors::core::Core as _,
 };
 
 use futures::executor::block_on;
@@ -129,7 +130,9 @@ impl Core for Function {
         match Self::form(env, fn_).type_of() {
             Type::Null | Type::Cons => std::mem::size_of::<Function>(),
             Type::Vector => std::mem::size_of::<Function>(),
-            Type::Symbol => std::mem::size_of::<Function>(),
+            Type::Symbol => {
+                std::mem::size_of::<Fixnum>() + Symbol::heap_size(env, Self::form(env, fn_))
+            }
             _ => panic!(),
         }
     }

--- a/src/mu/types/mod.rs
+++ b/src/mu/types/mod.rs
@@ -12,4 +12,3 @@ pub mod stream;
 pub mod struct_;
 pub mod symbol;
 pub mod vector;
-pub mod vector_image;

--- a/src/mu/types/namespace.rs
+++ b/src/mu/types/namespace.rs
@@ -17,8 +17,8 @@ use {
             cons::{Cons, Core as _},
             symbol::{Core as _, Symbol},
             vector::{Core as _, Vector},
-            vector_image::Core as _,
         },
+        vectors::core::Core as _,
     },
     std::{collections::HashMap, str},
 };

--- a/src/mu/types/stream.rs
+++ b/src/mu/types/stream.rs
@@ -26,8 +26,8 @@ use crate::{
         fixnum::{Core as _, Fixnum},
         symbol::{Core as _, Symbol},
         vector::{Core as _, Vector},
-        vector_image::Core as _,
     },
+    vectors::core::Core as _,
 };
 
 use futures::executor::block_on;

--- a/src/mu/types/struct_.rs
+++ b/src/mu/types/struct_.rs
@@ -18,13 +18,14 @@ use crate::{
         stream::{Core as _, Stream},
         symbol::{Core as _, Symbol},
         vector::Vector,
-        vector_image::Core as _,
     },
+    vectors::core::Core as _,
 };
 
 use futures::executor::block_on;
 
 // a struct is a vector with an arbitrary type keyword
+#[derive(Copy, Clone)]
 pub struct Struct {
     pub stype: Tag,
     pub vector: Tag,

--- a/src/mu/types/symbol.rs
+++ b/src/mu/types/symbol.rs
@@ -21,19 +21,21 @@ use {
             namespace::Namespace,
             stream::{Core as _, Stream},
             vector::{Core as _, Vector},
-            vector_image::Core as _,
         },
+        vectors::core::Core as _,
     },
     std::str,
 };
 
 use futures::executor::block_on;
 
+#[derive(Copy, Clone)]
 pub enum Symbol {
     Keyword(Tag),
     Symbol(SymbolImage),
 }
 
+#[derive(Copy, Clone)]
 pub struct SymbolImage {
     pub namespace: Tag,
     pub name: Tag,
@@ -177,6 +179,7 @@ impl Symbol {
                     gc.mark(env, value);
                 }
             }
+            Tag::Nursery(_) => panic!(),
         }
     }
 }
@@ -214,7 +217,7 @@ impl Core for Symbol {
         let name_sz = Heap::heap_size(env, Self::name(env, symbol));
         let value_sz = Heap::heap_size(env, Self::value(env, symbol));
 
-        std::mem::size_of::<Symbol>()
+        std::mem::size_of::<SymbolImage>()
             + if name_sz > 8 { name_sz } else { 0 }
             + if value_sz > 8 { value_sz } else { 0 }
     }

--- a/src/mu/vectors/core.rs
+++ b/src/mu/vectors/core.rs
@@ -1,0 +1,201 @@
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-License-Identifier: MIT
+
+//! typed vectors
+use {
+    crate::{
+        core::{
+            direct::{DirectTag, DirectType},
+            env::Env,
+            exception,
+            gc::HeapGcRef,
+            types::{Tag, Type},
+        },
+        streams::write::Core as _,
+        types::{
+            fixnum::Fixnum,
+            stream::{Core as _, Stream},
+            vector::{Core as _, Vector},
+        },
+        vectors::image::{VecImage, VecImageType, VectorImage, VectorImageType},
+    },
+    std::str,
+};
+
+use futures::executor::block_on;
+
+impl Vector {
+    pub fn to_image(env: &Env, tag: Tag) -> VectorImage {
+        let heap_ref = block_on(env.heap.read());
+
+        match tag.type_of() {
+            Type::Vector => match tag {
+                Tag::Indirect(image) => VectorImage {
+                    type_: Tag::from_slice(
+                        heap_ref.image_slice(image.image_id() as usize).unwrap(),
+                    ),
+                    length: Tag::from_slice(
+                        heap_ref.image_slice(image.image_id() as usize + 1).unwrap(),
+                    ),
+                },
+                _ => panic!(),
+            },
+            _ => panic!(),
+        }
+    }
+    pub fn gc_ref_image(heap_ref: &mut HeapGcRef, tag: Tag) -> VectorImage {
+        match tag.type_of() {
+            Type::Vector => match tag {
+                Tag::Indirect(image) => VectorImage {
+                    type_: Tag::from_slice(
+                        heap_ref.image_slice(image.image_id() as usize).unwrap(),
+                    ),
+                    length: Tag::from_slice(
+                        heap_ref.image_slice(image.image_id() as usize + 1).unwrap(),
+                    ),
+                },
+                _ => panic!(),
+            },
+            _ => panic!(),
+        }
+    }
+}
+
+pub trait Core<'a> {
+    fn evict(&self, _: &Env) -> Tag;
+    fn heap_size(_: &Env, _: Tag) -> usize;
+    fn write(_: &Env, _: Tag, _: bool, _: Tag) -> exception::Result<()>;
+}
+
+impl<'a> Core<'a> for Vector {
+    fn heap_size(env: &Env, vector: Tag) -> usize {
+        match vector {
+            Tag::Direct(_) => std::mem::size_of::<DirectTag>(),
+            Tag::Indirect(_) => {
+                let len = Self::length(env, vector);
+                let size = match Self::type_of(env, vector) {
+                    Type::Byte | Type::Char => 1,
+                    Type::Fixnum | Type::Float | Type::T => 8,
+                    _ => panic!(),
+                };
+
+                std::mem::size_of::<VectorImage>() + (size * len)
+            }
+            Tag::Nursery(_) => panic!(),
+        }
+    }
+
+    fn evict(&self, env: &Env) -> Tag {
+        match self {
+            Vector::Direct(tag) => *tag,
+            Vector::Indirect(image, ivec) => {
+                let indirect = match ivec {
+                    VectorImageType::T(_) => VecImageType::T(image, ivec),
+                    VectorImageType::Char(_) => VecImageType::Char(image, ivec),
+                    VectorImageType::Bit(_) => VecImageType::Bit(image, ivec),
+                    VectorImageType::Byte(_) => VecImageType::Byte(image, ivec),
+                    VectorImageType::Fixnum(_) => VecImageType::Fixnum(image, ivec),
+                    VectorImageType::Float(_) => VecImageType::Float(image, ivec),
+                };
+
+                match ivec {
+                    VectorImageType::T(_) => indirect.evict(env),
+                    _ => match Self::cached(env, &indirect) {
+                        Some(tag) => tag,
+                        None => {
+                            let tag = indirect.evict(env);
+
+                            Self::cache(env, tag);
+                            tag
+                        }
+                    },
+                }
+            }
+        }
+    }
+
+    fn write(env: &Env, vector: Tag, escape: bool, stream: Tag) -> exception::Result<()> {
+        match vector {
+            Tag::Direct(direct) => match direct.dtype() {
+                DirectType::String => match str::from_utf8(&vector.data(env).to_le_bytes()) {
+                    Ok(s) => {
+                        if escape {
+                            env.write_string("\"", stream).unwrap()
+                        }
+
+                        for nth in 0..DirectTag::length(vector) {
+                            Stream::write_char(env, stream, s.as_bytes()[nth] as char)?;
+                        }
+
+                        if escape {
+                            env.write_string("\"", stream).unwrap()
+                        }
+
+                        Ok(())
+                    }
+                    Err(_) => panic!(),
+                },
+                DirectType::ByteVec => {
+                    env.write_string("#(:byte", stream)?;
+
+                    for tag in Vector::iter(env, vector) {
+                        env.write_string(" ", stream)?;
+                        env.write_stream(tag, false, stream)?;
+                    }
+
+                    env.write_string(")", stream)
+                }
+                _ => panic!(),
+            },
+            Tag::Indirect(_) => match Self::type_of(env, vector) {
+                Type::Char => {
+                    if escape {
+                        env.write_string("\"", stream)?;
+                    }
+
+                    for ch in Vector::iter(env, vector) {
+                        env.write_stream(ch, false, stream)?;
+                    }
+
+                    if escape {
+                        env.write_string("\"", stream)?;
+                    }
+
+                    Ok(())
+                }
+                Type::Bit => {
+                    env.write_string("#*", stream)?;
+
+                    let _len = Vector::length(env, vector);
+                    for bit in Vector::iter(env, vector) {
+                        let digit = Fixnum::as_i64(bit);
+
+                        env.write_string(if digit == 1 { "1" } else { "0" }, stream)?
+                    }
+
+                    Ok(())
+                }
+                _ => {
+                    env.write_string("#(", stream)?;
+                    env.write_stream(Self::to_image(env, vector).type_, true, stream)?;
+
+                    for tag in Vector::iter(env, vector) {
+                        env.write_string(" ", stream)?;
+                        env.write_stream(tag, false, stream)?;
+                    }
+
+                    env.write_string(")", stream)
+                }
+            },
+            Tag::Nursery(_) => panic!(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}

--- a/src/mu/vectors/image.rs
+++ b/src/mu/vectors/image.rs
@@ -7,17 +7,14 @@ use {
         core::{
             direct::{DirectExt, DirectTag, DirectType},
             env::Env,
-            exception,
-            gc::{Gc, HeapGcRef},
+            gc::Gc,
             indirect::IndirectTag,
             types::{Tag, TagType, Type},
         },
-        streams::write::Core as _,
         types::{
             fixnum::{Core as _, Fixnum},
-            stream::{Core as _, Stream},
             symbol::{Core as _, Symbol},
-            vector::{Core as _, Vector},
+            vector::Vector,
         },
     },
     std::str,
@@ -25,11 +22,13 @@ use {
 
 use futures::executor::block_on;
 
+#[derive(Clone)]
 pub struct VectorImage {
     pub type_: Tag,  // type keyword
     pub length: Tag, // fixnum
 }
 
+#[derive(Clone)]
 pub enum VectorImageType {
     Bit(Vec<u8>),
     Byte(Vec<u8>),
@@ -387,172 +386,6 @@ impl<'a> VecImage for VecImageType<'a> {
                 Some(f32::from_le_bytes(slice[0..4].try_into().unwrap()).into())
             }
             _ => panic!(),
-        }
-    }
-}
-
-impl Vector {
-    pub fn to_image(env: &Env, tag: Tag) -> VectorImage {
-        let heap_ref = block_on(env.heap.read());
-
-        match tag.type_of() {
-            Type::Vector => match tag {
-                Tag::Indirect(image) => VectorImage {
-                    type_: Tag::from_slice(
-                        heap_ref.image_slice(image.image_id() as usize).unwrap(),
-                    ),
-                    length: Tag::from_slice(
-                        heap_ref.image_slice(image.image_id() as usize + 1).unwrap(),
-                    ),
-                },
-                _ => panic!(),
-            },
-            _ => panic!(),
-        }
-    }
-    pub fn gc_ref_image(heap_ref: &mut HeapGcRef, tag: Tag) -> VectorImage {
-        match tag.type_of() {
-            Type::Vector => match tag {
-                Tag::Indirect(image) => VectorImage {
-                    type_: Tag::from_slice(
-                        heap_ref.image_slice(image.image_id() as usize).unwrap(),
-                    ),
-                    length: Tag::from_slice(
-                        heap_ref.image_slice(image.image_id() as usize + 1).unwrap(),
-                    ),
-                },
-                _ => panic!(),
-            },
-            _ => panic!(),
-        }
-    }
-}
-
-pub trait Core<'a> {
-    fn evict(&self, _: &Env) -> Tag;
-    fn heap_size(_: &Env, _: Tag) -> usize;
-    fn write(_: &Env, _: Tag, _: bool, _: Tag) -> exception::Result<()>;
-}
-
-impl<'a> Core<'a> for Vector {
-    fn heap_size(env: &Env, vector: Tag) -> usize {
-        match vector {
-            Tag::Direct(_) => std::mem::size_of::<DirectTag>(),
-            Tag::Indirect(_) => {
-                let len = Self::length(env, vector);
-                let size = match Self::type_of(env, vector) {
-                    Type::Byte | Type::Char => 1,
-                    Type::Fixnum | Type::Float | Type::T => 8,
-                    _ => panic!(),
-                };
-
-                std::mem::size_of::<VectorImage>() + (size * len)
-            }
-        }
-    }
-
-    fn evict(&self, env: &Env) -> Tag {
-        match self {
-            Vector::Direct(tag) => *tag,
-            Vector::Indirect(image, ivec) => {
-                let indirect = match ivec {
-                    VectorImageType::T(_) => VecImageType::T(image, ivec),
-                    VectorImageType::Char(_) => VecImageType::Char(image, ivec),
-                    VectorImageType::Bit(_) => VecImageType::Bit(image, ivec),
-                    VectorImageType::Byte(_) => VecImageType::Byte(image, ivec),
-                    VectorImageType::Fixnum(_) => VecImageType::Fixnum(image, ivec),
-                    VectorImageType::Float(_) => VecImageType::Float(image, ivec),
-                };
-
-                match ivec {
-                    VectorImageType::T(_) => indirect.evict(env),
-                    _ => match Self::cached(env, &indirect) {
-                        Some(tag) => tag,
-                        None => {
-                            let tag = indirect.evict(env);
-
-                            Self::cache(env, tag);
-                            tag
-                        }
-                    },
-                }
-            }
-        }
-    }
-
-    fn write(env: &Env, vector: Tag, escape: bool, stream: Tag) -> exception::Result<()> {
-        match vector {
-            Tag::Direct(direct) => match direct.dtype() {
-                DirectType::String => match str::from_utf8(&vector.data(env).to_le_bytes()) {
-                    Ok(s) => {
-                        if escape {
-                            env.write_string("\"", stream).unwrap()
-                        }
-
-                        for nth in 0..DirectTag::length(vector) {
-                            Stream::write_char(env, stream, s.as_bytes()[nth] as char)?;
-                        }
-
-                        if escape {
-                            env.write_string("\"", stream).unwrap()
-                        }
-
-                        Ok(())
-                    }
-                    Err(_) => panic!(),
-                },
-                DirectType::ByteVec => {
-                    env.write_string("#(:byte", stream)?;
-
-                    for tag in Vector::iter(env, vector) {
-                        env.write_string(" ", stream)?;
-                        env.write_stream(tag, false, stream)?;
-                    }
-
-                    env.write_string(")", stream)
-                }
-                _ => panic!(),
-            },
-            Tag::Indirect(_) => match Self::type_of(env, vector) {
-                Type::Char => {
-                    if escape {
-                        env.write_string("\"", stream)?;
-                    }
-
-                    for ch in Vector::iter(env, vector) {
-                        env.write_stream(ch, false, stream)?;
-                    }
-
-                    if escape {
-                        env.write_string("\"", stream)?;
-                    }
-
-                    Ok(())
-                }
-                Type::Bit => {
-                    env.write_string("#*", stream)?;
-
-                    let _len = Vector::length(env, vector);
-                    for bit in Vector::iter(env, vector) {
-                        let digit = Fixnum::as_i64(bit);
-
-                        env.write_string(if digit == 1 { "1" } else { "0" }, stream)?
-                    }
-
-                    Ok(())
-                }
-                _ => {
-                    env.write_string("#(", stream)?;
-                    env.write_stream(Self::to_image(env, vector).type_, true, stream)?;
-
-                    for tag in Vector::iter(env, vector) {
-                        env.write_string(" ", stream)?;
-                        env.write_stream(tag, false, stream)?;
-                    }
-
-                    env.write_string(")", stream)
-                }
-            },
         }
     }
 }

--- a/src/mu/vectors/mod.rs
+++ b/src/mu/vectors/mod.rs
@@ -1,0 +1,7 @@
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-License-Identifier: MIT
+
+pub mod cache;
+pub mod core;
+pub mod image;
+pub mod read;

--- a/src/mu/vectors/read.rs
+++ b/src/mu/vectors/read.rs
@@ -1,0 +1,235 @@
+//  SPDX-FileCopyrightText: Copyright 2022 James M. Putnam (putnamjm.design@gmail.com)
+//  SPDX-License-Identifier: MIT
+
+//! vector read function
+use crate::{
+    core::{
+        env::Env,
+        exception::{self, Condition, Exception},
+        readtable::{map_char_syntax, SyntaxType},
+        types::{Tag, Type},
+    },
+    types::{
+        char::Char,
+        cons::{Cons, Core as _},
+        fixnum::Fixnum,
+        float::Float,
+        stream::{Core as _, Stream},
+        vector::{Vector, VTYPEMAP},
+    },
+    vectors::core::Core as _,
+};
+
+pub trait Core<'a> {
+    fn read(_: &Env, _: char, _: Tag) -> exception::Result<Tag>;
+}
+
+impl<'a> Core<'a> for Vector {
+    fn read(env: &Env, syntax: char, stream: Tag) -> exception::Result<Tag> {
+        match syntax {
+            '"' => {
+                let mut str: String = String::new();
+
+                loop {
+                    match Stream::read_char(env, stream)? {
+                        Some('"') => break,
+                        Some(ch) => match map_char_syntax(ch).unwrap() {
+                            SyntaxType::Escape => match Stream::read_char(env, stream)? {
+                                Some(ch) => str.push(ch),
+                                None => {
+                                    return Err(Exception::new(
+                                        env,
+                                        Condition::Eof,
+                                        "mu:read",
+                                        stream,
+                                    ));
+                                }
+                            },
+                            _ => str.push(ch),
+                        },
+                        None => {
+                            return Err(Exception::new(env, Condition::Eof, "mu:read", stream));
+                        }
+                    }
+                }
+
+                Ok(Self::from(str).evict(env))
+            }
+            '*' => {
+                let mut digits: String = String::new();
+
+                loop {
+                    match Stream::read_char(env, stream)? {
+                        Some(ch) => match map_char_syntax(ch).unwrap() {
+                            SyntaxType::Whitespace | SyntaxType::Tmacro => {
+                                Stream::unread_char(env, stream, ch)?;
+                                break;
+                            }
+                            SyntaxType::Escape => match Stream::read_char(env, stream)? {
+                                Some(ch) => {
+                                    if ch == '0' || ch == '1' {
+                                        digits.push(ch)
+                                    } else {
+                                        return Err(Exception::new(
+                                            env,
+                                            Condition::Eof,
+                                            "mu:read",
+                                            stream,
+                                        ));
+                                    }
+                                }
+                                None => {
+                                    return Err(Exception::new(
+                                        env,
+                                        Condition::Eof,
+                                        "mu:read",
+                                        stream,
+                                    ));
+                                }
+                            },
+                            _ => {
+                                if ch == '0' || ch == '1' {
+                                    digits.push(ch)
+                                } else {
+                                    return Err(Exception::new(
+                                        env,
+                                        Condition::Eof,
+                                        "mu:read",
+                                        stream,
+                                    ));
+                                }
+                            }
+                        },
+                        None => {
+                            return Err(Exception::new(env, Condition::Eof, "mu:read", stream));
+                        }
+                    }
+                }
+
+                let mut vec = vec![0; (digits.len() + 7) / 8];
+                let bvec = &mut vec;
+
+                for (i, ch) in digits.chars().enumerate() {
+                    if ch == '1' {
+                        bvec[i / 8] |= (1_i8) << (7 - i % 8)
+                    }
+                }
+
+                Ok(Self::from((vec, digits.len())).evict(env))
+            }
+            '(' => {
+                let vec_list = match Cons::read(env, stream) {
+                    Ok(list) => {
+                        if list.null_() {
+                            return Err(Exception::new(
+                                env,
+                                Condition::Type,
+                                "mu:read",
+                                Tag::nil(),
+                            ));
+                        }
+                        list
+                    }
+                    Err(_) => {
+                        return Err(Exception::new(env, Condition::Syntax, "mu:read", stream));
+                    }
+                };
+
+                let vec_type = Cons::car(env, vec_list);
+
+                match VTYPEMAP.iter().copied().find(|tab| vec_type.eq_(&tab.0)) {
+                    Some(tab) => match tab.1 {
+                        Type::T => {
+                            let vec = Cons::iter(env, Cons::cdr(env, vec_list))
+                                .map(|cons| Cons::car(env, cons))
+                                .collect::<Vec<Tag>>();
+
+                            Ok(Vector::from(vec).evict(env))
+                        }
+                        Type::Char => {
+                            let vec: exception::Result<String> =
+                                Cons::iter(env, Cons::cdr(env, vec_list))
+                                    .map(|cons| {
+                                        let ch = Cons::car(env, cons);
+                                        if ch.type_of() == Type::Char {
+                                            Ok(Char::as_char(env, ch))
+                                        } else {
+                                            Err(Exception::new(env, Condition::Type, "mu:read", ch))
+                                        }
+                                    })
+                                    .collect();
+
+                            Ok(Vector::from(vec?).evict(env))
+                        }
+                        Type::Byte => {
+                            let vec: exception::Result<Vec<u8>> =
+                                Cons::iter(env, Cons::cdr(env, vec_list))
+                                    .map(|cons| {
+                                        let fx = Cons::car(env, cons);
+                                        if fx.type_of() == Type::Fixnum {
+                                            let byte = Fixnum::as_i64(fx);
+                                            if !(0..255).contains(&byte) {
+                                                Err(Exception::new(
+                                                    env,
+                                                    Condition::Range,
+                                                    "mu:read",
+                                                    fx,
+                                                ))
+                                            } else {
+                                                Ok(byte as u8)
+                                            }
+                                        } else {
+                                            Err(Exception::new(env, Condition::Type, "mu:read", fx))
+                                        }
+                                    })
+                                    .collect();
+
+                            Ok(Vector::from(vec?).evict(env))
+                        }
+                        Type::Fixnum => {
+                            let vec: exception::Result<Vec<i64>> =
+                                Cons::iter(env, Cons::cdr(env, vec_list))
+                                    .map(|cons| {
+                                        let fx = Cons::car(env, cons);
+                                        if fx.type_of() == Type::Fixnum {
+                                            Ok(Fixnum::as_i64(fx))
+                                        } else {
+                                            Err(Exception::new(env, Condition::Type, "mu:read", fx))
+                                        }
+                                    })
+                                    .collect();
+
+                            Ok(Vector::from(vec?).evict(env))
+                        }
+                        Type::Float => {
+                            let vec: exception::Result<Vec<f32>> =
+                                Cons::iter(env, Cons::cdr(env, vec_list))
+                                    .map(|cons| {
+                                        let fl = Cons::car(env, cons);
+                                        if fl.type_of() == Type::Float {
+                                            Ok(Float::as_f32(env, fl))
+                                        } else {
+                                            Err(Exception::new(env, Condition::Type, "mu:read", fl))
+                                        }
+                                    })
+                                    .collect();
+
+                            Ok(Vector::from(vec?).evict(env))
+                        }
+                        _ => panic!(),
+                    },
+                    None => Err(Exception::new(env, Condition::Type, "mu:read", vec_type)),
+                }
+            }
+            _ => panic!(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}


### PR DESCRIPTION
partition vector implementation, add skeleton nursery support

docs: no change
tests: no change
srcs: create vector subdirectory, move types/vector_image into it, subdivide according to function