### PR TITLE
#581 - core: support core language modules

### DIFF
--- a/src/core/module.l
+++ b/src/core/module.l
@@ -8,9 +8,48 @@
    (:lambda ()
      (core:%mapcar mu:symbol-name (mu:namespace-symbols core:%modules%))))
 
-(mu:intern core "modules-loaded"
-   (:lambda ()
-     (core:%mapcar mu:symbol-name (mu:namespace-symbols core:%modules-loaded%))))
+(mu:intern core "%load-module-file"
+   (:lambda (path lang)
+     (:if (core:stringp path)
+          ((:lambda (stream)
+             (mu:fix
+              (:lambda (loop)
+                (:if (mu:eq loop core:%eof%)
+                     core:%eof%
+                     ((:lambda (form)
+                        (:if (mu:eq form core:%eof%)
+                             core:%eof%
+                             ((:lambda ()
+                                (:if (core:logor (mu:eq :mu lang) (core:null lang)) 
+                                     (mu:eval (mu:compile form))
+                                     (mu:eval (core:compile form)))
+                                (core:null loop)))))
+                      (mu:read stream () core:%eof%))))
+              ()))
+           (mu:open :file :input path))
+          (core:raise path 'core:%load-module-file "not a file path"))
+     :t))
+
+(mu:intern core "%load-module-def"
+   (:lambda (path)
+     (:if (core:stringp path)
+          ((:lambda (stream)
+             (mu:fix
+              (:lambda (loop)
+                (:if (mu:eq loop core:%eof%)
+                     core:%eof%
+                     ((:lambda (form)
+                        (:if (mu:eq form core:%eof%)
+                             core:%eof%
+                             ((:lambda ()
+                                (mu:eval (mu:compile form))
+                                ;;; do a bunch of parsing here
+                                (core:null loop)))))
+                      (mu:read stream () core:%eof%))))
+              ()))
+           (mu:open :file :input path))
+          (core:raise path 'core:%load-module-def "not a file path"))
+     :t))
 
 ;;;
 ;;; provide/require
@@ -29,40 +68,21 @@
           (:if (mu:find core:%modules% module)
                ()
                ((:lambda ()
-                  (core:%load-lib-file (core:%format () "/opt/mu/modules/~A/mod.def" `(,module)))
-                  ((:lambda (requires files)
-                     (core:%mapc
-                      (:lambda (module)
-                        (core:require module))
-                      requires)
-                     (core:%mapc
-                      (:lambda (file-name)
-                        (core:%load-lib-file (core:%format () "/opt/mu/modules/~A/~A" `(,module ,file-name))))
-                      files)
-                     :t)
-                   (mu:cdr (core:%assq :require (mu:symbol-value (mu:find core:%modules% module))))
-                   (mu:cdr (core:%assq :load (mu:symbol-value (mu:find core:%modules% module))))))))
-   (core:raise module 'core:require "is not a provided module"))))
-
-;;;
-;;; require-lib
-;;;
-(mu:intern core "%load-lib-file"
-   (:lambda (path)
-     (:if (core:stringp path)
-          ((:lambda (stream)
-             (mu:fix
-              (:lambda (loop)
-                (:if (mu:eq loop core:%eof%)
-                     core:%eof%
-                     ((:lambda (form)
-                        (:if (mu:eq form core:%eof%)
-                             core:%eof%
-                             ((:lambda ()
-                                (mu:eval (mu:compile form))
-                                (core:null loop)))))
-                      (mu:read stream () core:%eof%))))
-              ()))
-           (mu:open :file :input path))
-          (core:raise path 'core:load-file "not a file path"))
-     :t))
+                  (core:%load-module-def (core:%format () "/opt/mu/modules/~A/mod.def" `(,module)))
+                  ((:lambda (module-def)
+                     ((:lambda (requires files)
+                        (core:%mapc
+                         (:lambda (module)
+                           (core:require module))
+                         requires)
+                        (core:%mapc
+                         (:lambda (file-name)
+                           (core:%load-module-file
+                            (core:%format () "/opt/mu/modules/~A/~A" `(,module ,file-name))
+                            (mu:cdr (core:%assq :lang module-def))))
+                         files)
+                        :t)
+                      (mu:cdr (core:%assq :require module-def))
+                      (mu:cdr (core:%assq :load module-def))))
+                (mu:symbol-value (mu:find core:%modules% module))))))
+          (core:raise module 'core:require "is not a module name"))))

--- a/src/modules/common/describe/mod.def
+++ b/src/modules/common/describe/mod.def
@@ -7,6 +7,6 @@
 (core:provide
  "common/describe"
  '((:version . "0.0.1")
-   (:lang    . "mu")
+   (:lang    . :mu)
    (:require . ("common"))
    (:load    . ("describe.l"))))

--- a/src/modules/common/metrics/mod.def
+++ b/src/modules/common/metrics/mod.def
@@ -7,6 +7,6 @@
 (core:provide
  "common/metrics"
  '((:version . "0.0.1")
-   (:lang    . "mu")
+   (:lang    . :mu)
    (:require . ("common"))
    (:load    . ("room.l" "time.l"))))

--- a/src/modules/common/mod.def
+++ b/src/modules/common/mod.def
@@ -7,7 +7,7 @@
 (core:provide
  "common"
  '((:version . "0.0.1")
-   (:lang    . "mu")
+   (:lang    . :mu)
    (:load    . (
                 "common.l"
                 "boole.l"

--- a/src/modules/prelude/mod.def
+++ b/src/modules/prelude/mod.def
@@ -7,5 +7,5 @@
 (core:provide
  "prelude"
  '((:version . "0.0.1")
-   (:lang    . "mu")
+   (:lang    . :mu)
    (:load    . ("prelude.l" "list.l" "loader.l"))))

--- a/src/modules/prelude/repl/mod.def
+++ b/src/modules/prelude/repl/mod.def
@@ -7,6 +7,6 @@
 (core:provide
  "prelude/repl"
  '((:version . "0.0.1")
-   (:lang . "mu")
+   (:lang . :mu)
    (:require "prelude")
    (:load "break.l" "loop.l")))

--- a/tests/regression/core/module
+++ b/tests/regression/core/module
@@ -1,0 +1,2 @@
+(mu:type-of core:provide)	:func
+(mu:type-of core:require)	:func

--- a/tests/regression/core/tests
+++ b/tests/regression/core/tests
@@ -8,6 +8,7 @@ format
 lambda
 list
 macro
+module
 reader
 stream
 string


### PR DESCRIPTION
change module definition lang property to a keyword

docs: no change
tests: add nascent core module test
srcs: core:require now pays attention to module def :lang property