### PR TITLE
#546 - mux: symbols need work for modules

### DIFF
--- a/src/core/module.l
+++ b/src/core/module.l
@@ -31,7 +31,7 @@
      :t))
 
 (mu:intern core "%load-module-def"
-   (:lambda (path)
+   (:lambda (path module)
      (:if (core:stringp path)
           ((:lambda (stream)
              (mu:fix
@@ -43,13 +43,13 @@
                              core:%eof%
                              ((:lambda ()
                                 (mu:eval (mu:compile form))
-                                ;;; do a bunch of parsing here
+                                (mu:close stream)
                                 (core:null loop)))))
                       (mu:read stream () core:%eof%))))
               ()))
            (mu:open :file :input path))
           (core:raise path 'core:%load-module-def "not a file path"))
-     :t))
+     (mu:symbol-value (mu:find core:%modules% module))))
 
 ;;;
 ;;; provide/require
@@ -67,22 +67,24 @@
      (:if (core:stringp module)
           (:if (mu:find core:%modules% module)
                ()
-               ((:lambda ()
-                  (core:%load-module-def (core:%format () "/opt/mu/modules/~A/mod.def" `(,module)))
-                  ((:lambda (module-def)
-                     ((:lambda (requires files)
-                        (core:%mapc
-                         (:lambda (module)
-                           (core:require module))
-                         requires)
-                        (core:%mapc
-                         (:lambda (file-name)
-                           (core:%load-module-file
-                            (core:%format () "/opt/mu/modules/~A/~A" `(,module ,file-name))
-                            (mu:cdr (core:%assq :lang module-def))))
-                         files)
-                        :t)
-                      (mu:cdr (core:%assq :require module-def))
-                      (mu:cdr (core:%assq :load module-def))))
-                (mu:symbol-value (mu:find core:%modules% module))))))
+               ((:lambda (module-def)
+                  (:if module-def
+                       ((:lambda (requires files)
+                          (core:%mapc
+                           (:lambda (module)
+                             (core:require module))
+                           requires)
+                          (core:%mapc
+                           (:lambda (file-name)
+                             (core:%load-module-file
+                              (core:%format () "/opt/mu/modules/~A/~A" `(,module ,file-name))
+                              (mu:cdr (core:%assq :lang module-def))))
+                           files)
+                          :t)
+                        (mu:cdr (core:%assq :require module-def))
+                        (mu:cdr (core:%assq :load module-def)))
+                       (core:raise module 'core:require "cannot open module-def")))
+                  (core:%load-module-def
+                   (core:%format () "/opt/mu/modules/~A/mod.def" `(,module))
+                   module)))
           (core:raise module 'core:require "is not a module name"))))

--- a/tools/mux/Cargo.toml
+++ b/tools/mux/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mux"
-version = "0.0.12"
+version = "0.0.13"
 edition = "2021"
 
 [dependencies]

--- a/tools/mux/src/main.rs
+++ b/tools/mux/src/main.rs
@@ -33,7 +33,7 @@ use {
     },
 };
 
-const VERSION: &str = "0.0.12";
+const VERSION: &str = "0.0.13";
 
 pub fn usage() {
     println!("Usage: mux {} command [option...]", VERSION);
@@ -49,8 +49,10 @@ pub fn usage() {
     println!("    clean                              ; clean all artifacts");
     println!("    commit                             ; fmt and clippy, pre-commit checking");
     println!("    repl      mu | core | prelude      ; repl: mu, core, and prelude namespaces");
-    println!("    symbols   reference | crossref | metrics [--module=name | --namespace=name]");
-    println!("                                       ; symbol reports, defaults to mu");
+    println!(
+        "    symbols   reference | crossref | metrics [--namespace=name [--module-name=name]]"
+    );
+    println!("                                       ; symbol reports, defaults to core");
     println!("    test                               ; regression test suite");
     println!("    bench     base | current | footprint [--ntests=number]");
     println!("    profile   --config=path            ; create profile");


### PR DESCRIPTION
nascent module reference symbols now work, version bumped to 0.0.13

docs: no change
tests: no change
srcs: add module option to symbols reference, remove prelude specialization, fiddle usage message