### PR TITLE
#620 - mu: fix repl for modules

### DIFF
--- a/dist/Makefile
+++ b/dist/Makefile
@@ -27,7 +27,6 @@ dist:
 
 	@install -d $(BASE)
 	@install -d $(BASE)/bin
-	@install -d $(BASE)/dist
 	@install -d $(BASE)/doc
 	@install -d $(BASE)/lib
 	@install -d $(BASE)/modules
@@ -46,10 +45,9 @@ dist:
 	@install -m 644 $(DOCS)/refcards/*.pdf $(BASE)/doc
 	@install -m 644 $(DOCS)/reference/html/*.html $(BASE)/doc/html
 
-	@install -m 644 $(SRC)/dist/mu.l $(BASE)/dist
+	@install -m 644 $(SRC)/dist/mu.l $(BASE)/lib
 	@install -m 644 -D -t $(BASE)/lib/sysgen $(TOOLS)/sysgen/templates/*
-	@install -m 644 -D -t $(BASE)/lib/core $(SRC)/modules/core/*.l
-	@install -m 644 -D -t $(BASE)/lib/prelude $(SRC)/modules/prelude/*.l
+	@install -m 644 $(SRC)/image/image.l $(BASE)/lib
 
 	@for module in $(MODULES); do	\
 	    install -D -t $(BASE)/modules/$$module $(SRC)/modules/$$module/*.l;		\

--- a/src/modules/core/module.l
+++ b/src/modules/core/module.l
@@ -4,6 +4,8 @@
 ;;;
 ;;; modules
 ;;;
+(mu:intern core "%modules%" image:%modules%)
+
 (mu:intern core "modules"
    (:lambda ()
      (core:%mapcar mu:symbol-name (mu:namespace-symbols core:%modules%))))

--- a/src/mu/heaps/image.rs
+++ b/src/mu/heaps/image.rs
@@ -9,7 +9,7 @@ pub struct Image {
     image: Vec<u8>,
 }
 
-impl Image { }
+impl Image {}
 
 pub trait Core {
     fn image(&self) -> Vec<u8>;

--- a/tools/mux/src/repl.rs
+++ b/tools/mux/src/repl.rs
@@ -27,11 +27,13 @@ impl Repl {
                 let mut child = match ns {
                     Mode::Mu => Command::new("mu-sh").spawn().unwrap(),
                     Mode::Core => Command::new("mu-sh")
-                        .args(["-l", "/opt/mu/dist/core.l"])
+                        .args(["-l", "/opt/mu/lib/image.l"])
+                        .args(["-q", "(image:%require \"core\")"])
                         .spawn()
                         .unwrap(),
                     Mode::Prelude => Command::new("mu-sys")
-                        .args(["-l", "/opt/mu/dist/core.l"])
+                        .args(["-l", "/opt/mu/lib/image.l"])
+                        .args(["-q", "(image:%require \"core\")"])
                         .args(["-q", "(core:require \"prelude/repl\")"])
                         .args(["-e", "(prelude:repl)"])
                         .spawn()


### PR DESCRIPTION
mux now repls core and prelude

docs: no change
tests: no change
srcs: fiddle mux's repl sequence and add image.l to the distribution image 