### PR TITLE
#622 - mu: fix symbols for core module

### DIFF
--- a/tools/crossref/Makefile
+++ b/tools/crossref/Makefile
@@ -7,7 +7,7 @@ help:
 	@echo "crossref: mu/core symbol cross reference"
 
 crossref:
-	/opt/mu/bin/mu-sys -l /opt/mu/dist/core.l -l ./crossref.l -q '(crossref "crossref.out")'
+	@/opt/mu/bin/mu-sys -l /opt/mu/lib/image.l -q '(image:%require "core")' -l ./crossref.l -q '(crossref "crossref.out")'
 	@python3 crossref.py crossref.out
 
 clean:

--- a/tools/metrics/Makefile
+++ b/tools/metrics/Makefile
@@ -7,12 +7,12 @@ help:
 	@echo "symbols: core symbol counts"
 
 core:
-	@/opt/mu/bin/mu-sys -l /opt/mu/dist/core.l -l ./symbols.l -q '(symbols "core" "symbols.out")'
+	@/opt/mu/bin/mu-sys -l /opt/mu/lib/image.l -q '(image:%require "core")' -l ./symbols.l -q '(symbols "core" "symbols.out")'
 	@python3 symbols.py ../../dist/core.l symbols.out
 	@rm -f symbols.out
 
 prelude:
-	@/opt/mu/bin/mu-sys -l /opt/mu/dist/core.l -l /opt/mu/dist/prelude.l ./symbols.l -q '(symbols "prelude" "symbols.out")'
+	@/opt/mu/bin/mu-sys -l /opt/mu/lib/image.l -q '(image:%require "core")' -q '(core:require "prelude")' -l ./symbols.l -q '(symbols "prelude" "symbols.out")'
 	@python3 symbols.py ../../dist/prelude.l symbols.out
 	@rm -f symbols.out
 

--- a/tools/mux/src/symbols.rs
+++ b/tools/mux/src/symbols.rs
@@ -135,6 +135,18 @@ impl Symbols {
                 io::stdout().write_all(&output.stdout).unwrap();
                 io::stderr().write_all(&output.stderr).unwrap();
             }
+            "prelude" => {
+                let output = Command::new("make")
+                    .current_dir(home)
+                    .args(["-C", "tools/reference"])
+                    .arg("--no-print-directory")
+                    .arg("prelude")
+                    .output()
+                    .expect("command failed to execute");
+
+                io::stdout().write_all(&output.stdout).unwrap();
+                io::stderr().write_all(&output.stderr).unwrap();
+            }
             _ => {
                 let module = match Options::opt_value(&options, &Opt::Module("".to_string())) {
                     Some(name) => name,

--- a/tools/reference/Makefile
+++ b/tools/reference/Makefile
@@ -7,32 +7,32 @@ help:
 	@echo "reference: namespace symbol reference"
 
 mu:
-	@/opt/mu/bin/mu-sys -l /opt/mu/dist/core.l -l ./reference.l -q '(reference "mu" "reference.out")'
+	@/opt/mu/bin/mu-sys -l /opt/mu/lib/image.l -q '(image:%require "core")' -l ./reference.l -q '(reference "mu" "reference.out")'
 	@python3 reference.py reference.out
 	@rm -f reference.out
 
 core:
-	@/opt/mu/bin/mu-sys -l /opt/mu/dist/core.l -l ./reference.l -q '(reference "core" "reference.out")'
+	@/opt/mu/bin/mu-sys -l /opt/mu/lib/image.l -q '(image:%require "core")' -l ./reference.l -q '(reference "core" "reference.out")'
 	@python3 reference.py reference.out
 	@rm -f reference.out
 
 prelude:
-	@/opt/mu/bin/mu-sys -l /opt/mu/dist/core.l -l /opt/mu/dist/prelude.l -l ./reference.l -q '(reference "prelude" "reference.out")'
+	@/opt/mu/bin/mu-sys -l /opt/mu/lib/image.l -q '(image:%require "core")' -q '(core:require "prelude")' -l ./reference.l -q '(reference "prelude" "reference.out")'
 	@python3 reference.py reference.out
 	@rm -f reference.out
 
 mu-verbose:
-	@/opt/mu/bin/mu-sys -l /opt/mu/dist/core.l -l ./reference.l -q '(reference "mu" "reference.out")'
+	@/opt/mu/bin/mu-sys -l /opt/mu/lib/image.l -q '(image:%require "core")' -l ./reference.l -q '(reference "mu" "reference.out")'
 	@python3 verbose.py reference.out
 	@rm -f reference.out
 
 core-verbose:
-	@/opt/mu/bin/mu-sys -l /opt/mu/dist/core.l -l ./reference.l -q '(reference "core" "reference.out")'
+	@/opt/mu/bin/mu-sys -l /opt/mu/lib/image.l -q '(image:%require "core")' -l ./reference.l -q '(reference "core" "reference.out")'
 	@python3 verbose.py reference.out
 	@rm -f reference.out
 
 prelude-verbose:
-	@/opt/mu/bin/mu-sys -l /opt/mu/dist/core.l -l /opt/mu/dist/prelude.l -l ./reference.l -q '(reference "prelude" "reference.out")'
+	@/opt/mu/bin/mu-sys -l /opt/mu/lib/image.l -q '(image:%require "core")' -q '(core:require "prelude")' -l ./reference.l -q '(reference "prelude" "reference.out")'
 	@python3 verbose.py reference.out
 	@rm -f reference.out
 


### PR DESCRIPTION
symbols generation brought up to date with the core module

docs: no change
tests: no change
srcs: clean up mux symbols interface