### PR TITLE
#655 - common: defun/defmacro

### DIFF
--- a/src/modules/common/defun.l
+++ b/src/modules/common/defun.l
@@ -2,9 +2,12 @@
 ;;;  SPDX-License-Identifier: MIT
 
 ;;;
-;;; defun/defmacro/defvar
+;;; defun/defmacro
 ;;;
-#|
-(core:defmacro "defun"
-    (:lambda 
-|#
+(mu:eval (core:compile
+  '(%defmacro defun (name lambda &rest body)
+     `(mu:intern mu:%null-ns% ,(mu:symbol-name name) (%lambda ,lambda ,@body)))))
+
+(mu:eval (core:compile
+  '(%defmacro defmacro (name lambda &rest body)
+     `(%defmacro ,(mu:symbol-name name) ,lambda ,@body))))


### PR DESCRIPTION
implement defun and defmacro

docs: no change
tests: no change
srcs: fill out defun and demacro in common/defun.l. Needs tests.
