### PR TITLE
#658 - mu: reduce block_on overhead

### DIFF
--- a/src/mu/core/env.rs
+++ b/src/mu/core/env.rs
@@ -15,10 +15,9 @@ use {
         },
         vectors::cache::VecCacheMap,
     },
+    futures_locks::RwLock,
     std::collections::HashMap,
 };
-
-use futures_locks::RwLock;
 
 pub struct Env {
     // configuration
@@ -26,12 +25,13 @@ pub struct Env {
 
     // heap
     pub heap: RwLock<HeapAllocator>,
-    pub gc_root: RwLock<Vec<Tag>>,
     pub vector_map: RwLock<VecCacheMap>,
 
     // environments
-    pub dynamic: RwLock<Vec<(u64, usize)>>,
     pub lexical: RwLock<HashMap<u64, RwLock<Vec<Frame>>>>,
+
+    // dynamic state
+    pub dynamic: RwLock<Vec<(u64, usize)>>,
 
     // namespaces
     pub ns_map: RwLock<Vec<(Tag, String, Namespace)>>,
@@ -56,7 +56,6 @@ impl Env {
             config: config.clone(),
             dynamic: RwLock::new(Vec::new()),
             env_key: RwLock::new(Tag::nil()),
-            gc_root: RwLock::new(Vec::<Tag>::new()),
             heap: RwLock::new(HeapAllocator::new(config)),
             keyword_ns: Tag::nil(),
             lexical: RwLock::new(HashMap::new()),

--- a/src/mu/core/gc.rs
+++ b/src/mu/core/gc.rs
@@ -31,13 +31,6 @@ pub struct Gc {
 }
 
 impl Gc {
-    #[allow(dead_code)]
-    fn add_root(env: &Env, tag: Tag) {
-        let mut root_ref = block_on(env.gc_root.write());
-
-        root_ref.push(tag);
-    }
-
     pub fn mark(&mut self, env: &Env, tag: Tag) {
         match tag.type_of() {
             Type::Cons => Cons::mark(self, env, tag),
@@ -106,20 +99,13 @@ impl Gc {
     }
 
     pub fn gc(env: &Env) -> exception::Result<bool> {
-        let root_ref = block_on(env.gc_root.write());
         let mut gc = Gc {
             lock: block_on(env.heap.write()),
         };
 
         gc.lock.clear_marks();
-
         gc.namespaces(env);
         gc.lexicals(env);
-
-        for tag in &*root_ref {
-            gc.mark(env, *tag)
-        }
-
         gc.lock.sweep();
 
         Ok(true)

--- a/src/mu/features/env.rs
+++ b/src/mu/features/env.rs
@@ -2,27 +2,29 @@
 //  SPDX-License-Identifier: MIT
 
 //! env interface
-use crate::{
-    core::{
-        config::GcMode,
-        core::CoreFnDef,
-        direct::DirectTag,
-        env::Env as Env_,
-        exception::{self},
-        frame::Frame,
-        heap::HeapTypeInfo,
-        indirect::IndirectTag,
-        types::{Tag, Type},
+use {
+    crate::{
+        core::{
+            config::GcMode,
+            core::CoreFnDef,
+            direct::DirectTag,
+            env::Env as Env_,
+            exception::{self},
+            frame::Frame,
+            heap::HeapTypeInfo,
+            indirect::IndirectTag,
+            types::{Tag, Type},
+        },
+        features::feature::Feature,
+        types::{
+            cons::Cons, fixnum::Fixnum, function::Function, struct_::Struct, symbol::Symbol,
+            vector::Vector,
+        },
     },
-    features::feature::Feature,
-    types::{
-        cons::Cons, fixnum::Fixnum, function::Function, struct_::Struct, symbol::Symbol,
-        vector::Vector,
-    },
+    futures::executor::block_on,
+    futures_locks::RwLock,
+    std::collections::HashMap,
 };
-use futures::executor::block_on;
-use futures_locks::RwLock;
-use std::collections::HashMap;
 
 lazy_static! {
     pub static ref ENV_SYMBOLS: RwLock<HashMap<String, Tag>> = RwLock::new(HashMap::new());
@@ -80,10 +82,8 @@ impl Env for Feature {
 
     fn heap_type(env: &Env_, type_: Type) -> HeapTypeInfo {
         let heap_ref = block_on(env.heap.read());
-        let alloc_ref = block_on(heap_ref.alloc_map.read());
-        let alloc_type = block_on(alloc_ref[type_ as usize].read());
 
-        *alloc_type
+        heap_ref.alloc_map[type_ as usize]
     }
 
     fn heap_stat(env: &Env_) -> Tag {

--- a/src/mu/features/prof.rs
+++ b/src/mu/features/prof.rs
@@ -9,7 +9,6 @@ use crate::{
         env::Env,
         exception::{self, Condition, Exception},
         frame::Frame,
-        namespace::Namespace,
         types::{Tag, Type},
     },
     features::feature::Feature,

--- a/src/mu/features/semispace_heap.rs
+++ b/src/mu/features/semispace_heap.rs
@@ -321,10 +321,8 @@ impl SemiSpaceAllocator {
 
     pub fn heap_type(env: &Env, type_: Type) -> HeapTypeInfo {
         let heap_ref = block_on(env.heap.read());
-        let alloc_ref = block_on(heap_ref.alloc_map.read());
-        let alloc_type = block_on(alloc_ref[type_ as usize].read());
 
-        *alloc_type
+        heap_ref.alloc_map[type_ as usize]
     }
 }
 

--- a/tests/valgrind/Makefile
+++ b/tests/valgrind/Makefile
@@ -1,6 +1,7 @@
 #
 # valgrind makefile
 #
+PHONY: clean
 VALGRIND='((:lambda (g) (mu:apply g (mu:cons g (mu:cons 101010101 (mu:cons 11011 ()))))) (:lambda (g a b) (:if (mu:eq 0 b) a (mu:apply g (mu:cons g (mu:cons b (mu:cons (mu:sub a (mu:mul b (mu:div a b))) ()))))))) '
 
 MU_SYS = ../../dist/mu-sys
@@ -9,27 +10,46 @@ help:
 	@echo "valgrind makefile -----------------"
 	@echo
 	@echo "--- options"
-	@echo "    valgrind - generate memcheck, callgrind, cachegrind reports"
+	@echo "    valgrind - generate memcheck, callgrind, cachegrind reports for test form"
+	@echo "    null - generate memcheck, callgrind, cachegrind reports for no form"
+	@echo "    all - valgrind null"
 	@echo "    clean - remove reports"
 
-valgrind: memcheck callgrind cachegrind clean
-
+all: valgrind null
+valgrind: memcheck callgrind cachegrind
+null: nullcheck nullcall nullcache
 memcheck:
 	@valgrind --tool=memcheck --leak-check=yes --show-reachable=yes --num-callers=10 \
 		--leak-resolution=med --show-leak-kinds=definite	\
-		$(MU_SYS) -p      					\
+		$(MU_SYS)	      					\
 		    -q $(VALGRIND) > memcheck.report 2>&1 || true
 
 callgrind:
 	@valgrind --tool=callgrind     	\
-		$(MU_SYS) -p      	\
+		$(MU_SYS)	      	\
 		    -q $(VALGRIND) > callgrind.report 2>&1 || true
 	@callgrind_annotate --auto=yes callgrind.out.* >> callgrind.report
 
 cachegrind:
 	@valgrind --tool=cachegrind	\
-		$(MU_SYS) -p      	\
+		$(MU_SYS)	      	\
 		    -q $(VALGRIND) > cachegrind.report 2>&1 || true
+	@make clean
+
+nullcheck:
+	@valgrind --tool=memcheck --leak-check=yes --show-reachable=yes --num-callers=10 \
+		--leak-resolution=med --show-leak-kinds=definite	\
+		$(MU_SYS) > nullcheck.report 2>&1 || true
+
+nullcall:
+	@valgrind --tool=callgrind     	\
+		$(MU_SYS) > nullcall.report 2>&1 || true
+	@callgrind_annotate --auto=yes callgrind.out.* >> nullcall.report
+
+nullcache:
+	@valgrind --tool=cachegrind	\
+		$(MU_SYS) > nullcache.report 2>&1 || true
+	@make clean
 
 clean:
 	@rm -f *.out.*


### PR DESCRIPTION
reduce unnecessary locking in heap allocator

docs: no change
tests: reduces block_on overhead from 8.7 to 6.1% in null valgrind case. footprint benchmark shows improvment in startup time
srcs: rework heap allocator data structure