### PR TITLE
#679 - mux: repl prelude

### DIFF
--- a/src/core/module.l
+++ b/src/core/module.l
@@ -39,14 +39,14 @@
                ((:lambda (stream)
                   (mu:fix
                    (:lambda (loop)
-                     (:if (mu:eq loop core:%eof%)
+                     (:if (mu:eq core:%eof% loop)
                           core:%eof%
                           ((:lambda (form)
-                             (:if (mu:eq form core:%eof%)
+                             (:if (mu:eq core:%eof% form)
                                   core:%eof%
-                                  (:lambda ()
+                                  ((:lambda ()
                                     (mu:eval (mu:compile form))
-                                    (core:null loop))))
+                                    (core:null loop)))))
                            (mu:read stream () core:%eof%))))
                    ()))
                 (mu:open :file :input path :t)))
@@ -97,7 +97,9 @@
                            (:lambda (module)
                              (core:require module))
                            requires)
-                          (mu:make-namespace ns)
+                          (:if (core:%findl-if (:lambda (el) (mu:eq el ns)) (mu:namespace-map))
+                               ()
+                               (mu:make-namespace ns))
                           (core:%mapc
                            (:lambda (file-name)
                              (core:%load-module-file
@@ -126,7 +128,9 @@
                            (:lambda (module)
                              (core:require module))
                            requires)
-                          (mu:make-namespace ns)
+                          (:if (core:%findl-if (:lambda (el) (mu:eq el ns)) (mu:namespace-map))
+                               ()
+                               (mu:make-namespace ns))
                           (core:%mapc
                            (:lambda (file-name)
                              (core:%load-module-file

--- a/src/modules/prelude/mod.def
+++ b/src/modules/prelude/mod.def
@@ -9,4 +9,5 @@
  '((:version . "0.0.1")
    (:lang    . :mu)
    (:ns      . "prelude")
+   (:require . ())
    (:load    . ("prelude.l" "list.l" "loader.l"))))

--- a/src/modules/prelude/prelude.l
+++ b/src/modules/prelude/prelude.l
@@ -4,7 +4,7 @@
 ;;;
 ;;; prelude namespace
 ;;;
-(mu:intern mu:%null-ns% "prelude" (mu:make-namespace "prelude"))
+(mu:intern mu:%null-ns% "prelude" (mu:find-namespace "prelude"))
 
 #| https://www.lispworks.com/documentation/HyperSpec/Issues/iss172_w.htm
 (defun compose (&rest fns)

--- a/src/modules/prelude/repl/mod.def
+++ b/src/modules/prelude/repl/mod.def
@@ -7,7 +7,7 @@
 (core:provide
  "prelude/repl"
  '((:version . "0.0.1")
-   (:lang . :mu)
-   (:ns   . "prelude")
-   (:require "prelude")
-   (:load "break.l" "loop.l")))
+   (:lang    . :core)
+   (:ns      . "prelude")
+   (:require . ("prelude"))
+   (:load    . ("break.l" "loop.l"))))


### PR DESCRIPTION
prelude is now a functionaal, first class module

docs: no change
tests: no change
srcs: chanage the way core:require manages nested modules