### PR TITLE
#681 - mu: boundp is wrong

### DIFF
--- a/src/mu/types/symbol.rs
+++ b/src/mu/types/symbol.rs
@@ -441,12 +441,12 @@ impl CoreFunction for Symbol {
         let symbol = fp.argv[0];
 
         fp.value = match symbol.type_of() {
-            Type::Keyword => symbol,
+            Type::Keyword | Type::Null => Self::keyword("t"),
             Type::Symbol => {
-                if !Self::is_bound(env, symbol) {
-                    Tag::nil()
-                } else {
+                if Self::is_bound(env, symbol) {
                     symbol
+                } else {
+                    Tag::nil()
                 }
             }
             _ => return Err(Exception::new(env, Condition::Type, "mu:boundp", symbol)),

--- a/tests/regression/namespaces/mu/symbol
+++ b/tests/regression/namespaces/mu/symbol
@@ -1,5 +1,7 @@
 (mu:boundp 'mu:foo)	:nil
 (mu:boundp 'mu:*standard-input*)	mu:*standard-input*
+(mu:boundp :foo)	:t
+(mu:boundp ())	:t
 (mu:symbol-name 'mu:*standard-input*)	"*standard-input*"
 (mu:symbol-namespace 'mu:*standard-input*)	#<:ns "mu">
 (mu:symbol-namespace 'std-in)	#<:ns "">


### PR DESCRIPTION
now it's right, (mu:boundp ()) is :t, rather than :nil

docs: no change
tests: add mu boundp tests
srcs: mu boundp implementation  changes
