### PR TITLE
#688 - core: compiler lexical symbol resolution broken

### DIFF
--- a/src/core/closure.l
+++ b/src/core/closure.l
@@ -36,15 +36,47 @@
           ,(mu:cons :arity    (mu:sub (mu:length requires) (:if rest-sym 1 0)))
           ,(mu:cons :env      env)))))
 
-;;;
-;;; predicates
-;;;
 (mu:intern core "%closurep"
    (:lambda (function)
      (:if (core:%core-type-p function)
           (mu:eq '%closure (core:type-of function))
           ())))
 
+
+;;;
+;;; env deftype
+;;;
+
+;;;
+;;;  (:frame   . :fixnum)     frame function id
+;;;  (:symbols . :listp)      lexical symbols
+;;;  (:name    . :symbol)     closure symbol
+;;;
+(core:def-type "%env"
+    '((:frame   . :fixnum)
+      (:symbols . :listp)
+      (:name    . :symbol)))
+
+(mu:intern core "%env-prop"
+   (:lambda (prop env)
+     (mu:cdr (core:%type-ref prop env))))
+
+(mu:intern core "%make-env"
+   (:lambda (frame symbols name)
+     (core:%make-core-type "%closure"
+       `(,(mu:cons :frame     frame)
+          ,(mu:cons :symbols  symbols)
+          ,(mu:cons :name     name)))))
+
+(mu:intern core "%envp"
+   (:lambda (function)
+     (:if (core:%core-type-p function)
+          (mu:eq '%env (core:type-of function))
+          ())))
+
+;;;
+;;; predicates
+;;;
 (mu:intern core "functionp"
    (:lambda (function)
      (:if (mu:eq :func (mu:type-of function))
@@ -59,11 +91,21 @@
      (:if (core:%findl-if (:lambda (el) (core:null (mu:eq :symbol (mu:type-of el)))) lambda)
           (core:raise lambda 'core:%compile-closure "malformed lambda expression")
           ((:lambda (desc)
-             ((:lambda (body)
-                (:if (core:%or (core:fixnump desc) (core:null body))
-                     (core:%make-closure lambda () `(:lambda ,lambda ,@body) ())
-                     (core:%make-closure (mu:car desc) (mu:cdr desc) `(:lambda ,(mu:car desc) ,@body) ())))
-              (core:%mapcar (:lambda (form) (core:%compile form env)) body)))
+             ((:lambda (env)
+                ((:lambda (body)
+                   ((:lambda (closure)
+                      (core:%add-frame (core:%env-prop :name (mu:car env)) (core:%closure-prop :mu closure))
+                      closure)
+                    (core:%make-closure (mu:car desc) (mu:cdr desc) `(:lambda ,(mu:car desc) ,@body) ())))                   
+                 (core:%mapcar
+                  (:lambda (form)
+                    (core:%compile form env))
+                  body)))
+              (mu:cons (core:%make-env (mu:length env) (mu:car desc) (core:gensym)) env)))
+          ((:lambda (desc)
+             (:if (core:%or (core:fixnump desc) (core:null body))
+                  (core:%list lambda)
+                  desc))
            (core:%foldl
             (:lambda (el acc)
               (:if (core:numberp acc)
@@ -76,7 +118,7 @@
                         (mu:add 1 acc))
                    acc))
             0
-            lambda)))))
+            lambda))))))
 
 #|
 ;;;

--- a/src/core/compile.l
+++ b/src/core/compile.l
@@ -62,15 +62,47 @@
 ;;;
 ;;; core compiler
 ;;;
-(mu:intern core "%resolve-symbol"
-   (:lambda (symbol env)
-;;;     (core:warn `(,symbol ,env) "compiling symbol")
-     symbol))
+(mu:intern core "%frame-map" (mu:open :string :bidir "" :t))
+
+(mu:intern core "%add-frame"
+   (:lambda (name func)
+     (mu:write #\space () core:%frame-map)
+     (mu:write (mu:cons name (mu:repr :vector func)) () core:%frame-map)))
+
+(mu:intern core "%frame-ref"
+   (:lambda (binding index offset)
+     ((:lambda (name)
+        ((:lambda (frames)
+           (mu:%frame-ref frames offset))
+         (mu:symbol-value (mu:intern core:%closure-ns% name ()))))
+        (mu:symbol-name (core:%env-prop :name binding)))))
+
+(mu:intern core "%resolve-lexical"
+   (:lambda (symbol env)          
+     (:if (mu:eq mu:%null-ns% (mu:symbol-namespace symbol))
+          ((:lambda (binding)
+             (:if (core:null binding)
+                  symbol
+                  ((:lambda (tag index)
+                     `(core:%frame-ref ,binding ,tag ,index))
+                   (core:%env-prop :frame binding)
+                   (core:%positionl-if
+                    (:lambda (sym)
+                      (mu:eq sym symbol))
+                    (core:%env-prop :symbols binding)))))
+           (core:%findl-if
+            (:lambda (binding)
+              (core:%findl-if
+               (:lambda (sym)
+                 (mu:eq sym symbol))
+               (core:%env-prop :symbols binding)))
+            env))
+          symbol)))
 
 (mu:intern core "%compile"
    (:lambda (form env)
-     (:if (core:symbolp form)
-          (core:%resolve-symbol form env)
+     (:if (mu:eq :symbol (mu:type-of form))
+          (core:%resolve-lexical form env)
           (:if (core:consp form)
                ((:lambda (function-form arg-list)
                   (:if (core:keywordp function-form)
@@ -100,6 +132,19 @@
 
 (mu:intern core "compile"
    (:lambda (form)
+     (mu:write #\( () core:%frame-map)
      ((:lambda (mu-form)
         (mu:compile mu-form))
-      (core:%compile form ()))))
+      ((:lambda (form)
+         (mu:write #\) () core:%frame-map)
+         ((:lambda (frame-map)
+            (core:%mapc
+             (:lambda (frame-ref)
+               (mu:intern
+                core:%closure-ns%
+                (mu:symbol-name (mu:car frame-ref))
+                (mu:repr :t (mu:cdr frame-ref))))
+             frame-map)
+            form)
+          (mu:read core:%frame-map () ())))
+       (core:%compile form ())))))

--- a/src/core/core.l
+++ b/src/core/core.l
@@ -9,6 +9,7 @@
 (mu:intern core "%modules-ns%" (mu:make-namespace "%modules%"))
 (mu:intern core "%symbol-macro-ns%" (mu:make-namespace "%symbol-macros%"))
 (mu:intern core "%types-ns%" (mu:make-namespace "%core-types%"))
+(mu:intern core "%closure-ns%" (mu:make-namespace "%closure-ns%"))
 
 ;;;
 ;;; predicates

--- a/src/core/fasl.def
+++ b/src/core/fasl.def
@@ -11,6 +11,7 @@
    (:lang    . :mu)
    (:load    . (
                 "core.l"
+                "deftype.l"
                 "compile.l"
                 "string.l"
                 "format.l"
@@ -26,7 +27,6 @@
                 "read-macro.l"
                 "symbol.l"
                 "symbol-macro.l"
-                "deftype.l"
                 "typespec.l"
                 "exception.l"
                 "macro.l"

--- a/src/core/list.l
+++ b/src/core/list.l
@@ -42,7 +42,7 @@
                                 (mu:cons loop  ())
                                 (mu:add loop 1)))))
                0)))
-           (mu:length list))
+           (mu:sub (mu:length list) 1))
           ())))
    
 ;;;

--- a/src/core/mod.def
+++ b/src/core/mod.def
@@ -11,6 +11,7 @@
    (:lang    . :mu)
    (:load    . (
                 "core.l"
+                "deftype.l"
                 "compile.l"
                 "string.l"
                 "format.l"
@@ -26,7 +27,6 @@
                 "read-macro.l"
                 "symbol.l"
                 "symbol-macro.l"
-                "deftype.l"
                 "typespec.l"
                 "exception.l"
                 "macro.l"

--- a/src/core/test.def
+++ b/src/core/test.def
@@ -11,6 +11,7 @@
    (:lang    . :mu)
    (:load    . (
                 "core.l"
+                "deftype.l"
                 "compile.l"
                 "string.l"
                 "format.l"
@@ -26,7 +27,6 @@
                 "read-macro.l"
                 "symbol.l"
                 "symbol-macro.l"
-                "deftype.l"
                 "typespec.l"
                 "exception.l"
                 "macro.l"

--- a/tests/performance/core/closure
+++ b/tests/performance/core/closure
@@ -3,3 +3,4 @@
 (core:compile '(%lambda (&rest c)))
 (core:compile '(%lambda (a b) (mu:add a b)))
 (core:compile '(%lambda (a b &rest c) (mu:add a b) c))
+(mu:eval (core:compile '((%lambda (a) (%if a a)) 1)))

--- a/tests/regression/namespaces/core/closure
+++ b/tests/regression/namespaces/core/closure
@@ -1,1 +1,2 @@
 (mu:type-of core:apply)	:func
+(mu:eval (core:compile '((%lambda (a) (%if a a)) 1)))	1


### PR DESCRIPTION
trivial lexical references work. now we need to make them work in general.

docs: no change
tests: add trivial %lambda lexical reference to both regression and performance
srcs: completely rework lexical reference compilation in core