### PR TITLE
#758 - mu: rethink core streams management

### DIFF
--- a/src/mu/core/core.rs
+++ b/src/mu/core/core.rs
@@ -146,7 +146,8 @@ pub struct Core {
     pub env_map: RwLock<HashMap<u64, Env>>,
     pub features: RwLock<Vec<Feature>>,
     pub stdio: RwLock<(Tag, Tag, Tag)>,
-    pub streams: RwLock<Vec<RwLock<Stream>>>,
+    pub streams: RwLock<HashMap<u64, RwLock<Stream>>>,
+    pub stream_id: RwLock<u64>,
     pub symbols: RwLock<HashMap<String, Tag>>,
 }
 
@@ -162,7 +163,8 @@ impl Core {
             env_map: RwLock::new(HashMap::new()),
             features: RwLock::new(Vec::new()),
             stdio: RwLock::new((Tag::nil(), Tag::nil(), Tag::nil())),
-            streams: RwLock::new(Vec::new()),
+            streams: RwLock::new(HashMap::new()),
+            stream_id: RwLock::new(0),
             symbols: RwLock::new(HashMap::new()),
         }
     }

--- a/src/mu/features/semispace.rs
+++ b/src/mu/features/semispace.rs
@@ -320,12 +320,12 @@ impl SemiSpaceAllocator {
     }
 
     /*
-    pub fn heap_type(env: &Env, type_: Type) -> HeapTypeInfo {
-        let heap_ref = block_on(env.heap.read());
+        pub fn heap_type(env: &Env, type_: Type) -> HeapTypeInfo {
+            let heap_ref = block_on(env.heap.read());
 
-        heap_ref.alloc_map[type_ as usize]
-}
-    */
+            heap_ref.alloc_map[type_ as usize]
+    }
+        */
 }
 
 pub trait GC {

--- a/src/mu/streams/operator.rs
+++ b/src/mu/streams/operator.rs
@@ -94,18 +94,24 @@ impl SystemStream {
             None => Err(Exception::new(env, Condition::Open, "mu:open", Tag::nil())),
             Some(_) => {
                 let mut streams_ref = block_on(CORE.streams.write());
-                let index = streams_ref.len();
+                let mut id = block_on(CORE.stream_id.write());
+                let stream_id = *id;
 
-                streams_ref.push(RwLock::new(Stream {
-                    index,
-                    system: system_stream.unwrap(),
-                    open: true,
-                    direction: Symbol::keyword(if is_input { "input" } else { "output" }),
-                    unch: Tag::nil(),
-                }));
+                *id += 1;
+
+                streams_ref.insert(
+                    stream_id,
+                    RwLock::new(Stream {
+                        id: stream_id,
+                        system: system_stream.unwrap(),
+                        open: true,
+                        direction: Symbol::keyword(if is_input { "input" } else { "output" }),
+                        unch: Tag::nil(),
+                    }),
+                );
 
                 Ok(DirectTag::to_tag(
-                    index as u64,
+                    stream_id,
                     DirectExt::ExtType(ExtType::Stream),
                     DirectType::Ext,
                 ))
@@ -141,22 +147,28 @@ impl SystemStream {
             None => Err(Exception::new(env, Condition::Open, "env:open", Tag::nil())),
             Some(_) => {
                 let mut streams_ref = block_on(CORE.streams.write());
-                let index = streams_ref.len();
+                let mut id = block_on(CORE.stream_id.write());
+                let stream_id = *id;
 
-                streams_ref.push(RwLock::new(Stream {
-                    index,
-                    open: true,
-                    system: system_stream.unwrap(),
-                    direction: match dir {
-                        StringDirection::Input => Symbol::keyword("input"),
-                        StringDirection::Output => Symbol::keyword("output"),
-                        StringDirection::Bidir => Symbol::keyword("bidir"),
-                    },
-                    unch: Tag::nil(),
-                }));
+                *id += 1;
+
+                streams_ref.insert(
+                    stream_id,
+                    RwLock::new(Stream {
+                        id: stream_id,
+                        open: true,
+                        system: system_stream.unwrap(),
+                        direction: match dir {
+                            StringDirection::Input => Symbol::keyword("input"),
+                            StringDirection::Output => Symbol::keyword("output"),
+                            StringDirection::Bidir => Symbol::keyword("bidir"),
+                        },
+                        unch: Tag::nil(),
+                    }),
+                );
 
                 Ok(DirectTag::to_tag(
-                    index as u64,
+                    stream_id,
                     DirectExt::ExtType(ExtType::Stream),
                     DirectType::Ext,
                 ))
@@ -180,24 +192,30 @@ impl SystemStream {
         match std_stream {
             SystemStream::StdInput | SystemStream::StdOutput | SystemStream::StdError => {
                 let mut streams_ref = block_on(core.streams.write());
-                let index = streams_ref.len();
+                let mut id = block_on(core.stream_id.write());
+                let stream_id = *id;
 
-                streams_ref.push(RwLock::new(Stream {
-                    index,
-                    open: true,
-                    direction: match &std_stream {
-                        SystemStream::StdInput => Symbol::keyword("input"),
-                        SystemStream::StdOutput | SystemStream::StdError => {
-                            Symbol::keyword("output")
-                        }
-                        _ => panic!(),
-                    },
-                    system: std_stream,
-                    unch: Tag::nil(),
-                }));
+                *id += 1;
+
+                streams_ref.insert(
+                    stream_id,
+                    RwLock::new(Stream {
+                        id: stream_id,
+                        open: true,
+                        direction: match &std_stream {
+                            SystemStream::StdInput => Symbol::keyword("input"),
+                            SystemStream::StdOutput | SystemStream::StdError => {
+                                Symbol::keyword("output")
+                            }
+                            _ => panic!(),
+                        },
+                        system: std_stream,
+                        unch: Tag::nil(),
+                    }),
+                );
 
                 Ok(DirectTag::to_tag(
-                    index as u64,
+                    stream_id,
                     DirectExt::ExtType(ExtType::Stream),
                     DirectType::Ext,
                 ))


### PR DESCRIPTION
reorganize core streams data structure

docs: no change
tests: no change
src: CORE now uses a hashmap to map a stream direct tag to Stream