### PR TITLE
#773 - mu: auto gc on heap high water mark

### DIFF
--- a/src/mu/core/gc.rs
+++ b/src/mu/core/gc.rs
@@ -99,6 +99,17 @@ impl Gc {
         }
     }
 
+    pub fn gc_lock(env: &Env, lock: HeapGcRef) -> exception::Result<bool> {
+        let mut gc = Gc { lock };
+
+        gc.lock.clear_marks();
+        gc.namespaces(env);
+        gc.lexicals(env);
+        gc.lock.sweep();
+
+        Ok(true)
+    }
+
     pub fn gc(env: &Env) -> exception::Result<bool> {
         let mut gc = Gc {
             lock: block_on(env.heap.write()),

--- a/src/mu/vectors/image.rs
+++ b/src/mu/vectors/image.rs
@@ -187,7 +187,8 @@ impl VecImage for VecImageType<'_> {
 
                 heap_ref
                     .alloc(&Self::image(image), Some(data), Type::Vector as u8)
-                    .unwrap() as u64
+                    .unwrap()
+                    .1 as u64
             }
             VecImageType::Bit(image, ivec) => {
                 let data = match ivec {
@@ -197,7 +198,8 @@ impl VecImage for VecImageType<'_> {
 
                 heap_ref
                     .alloc(&Self::image(image), Some(data), Type::Vector as u8)
-                    .unwrap() as u64
+                    .unwrap()
+                    .1 as u64
             }
             VecImageType::Char(image, ivec) => {
                 let data = match ivec {
@@ -207,7 +209,8 @@ impl VecImage for VecImageType<'_> {
 
                 heap_ref
                     .alloc(&Self::image(image), Some(data), Type::Vector as u8)
-                    .unwrap() as u64
+                    .unwrap()
+                    .1 as u64
             }
             VecImageType::T(image, ivec) => {
                 let mut slices = Self::image(image);
@@ -219,7 +222,7 @@ impl VecImage for VecImageType<'_> {
                     _ => panic!(),
                 }
 
-                heap_ref.alloc(&slices, None, Type::Vector as u8).unwrap() as u64
+                heap_ref.alloc(&slices, None, Type::Vector as u8).unwrap().1 as u64
             }
             VecImageType::Fixnum(image, ivec) => {
                 let mut slices = Self::image(image);
@@ -231,7 +234,7 @@ impl VecImage for VecImageType<'_> {
                     _ => panic!(),
                 }
 
-                heap_ref.alloc(&slices, None, Type::Vector as u8).unwrap() as u64
+                heap_ref.alloc(&slices, None, Type::Vector as u8).unwrap().1 as u64
             }
             VecImageType::Float(image, ivec) => {
                 let data = match ivec {
@@ -249,7 +252,8 @@ impl VecImage for VecImageType<'_> {
 
                 heap_ref
                     .alloc(&Self::image(image), Some(&data), Type::Vector as u8)
-                    .unwrap() as u64
+                    .unwrap()
+                    .1 as u64
             }
         };
 


### PR DESCRIPTION
better heap space management. we can now compute large values (> 14) of naive fib 

docs: no change
tests: no change
src: detect heap high water mark and gc 