### PR TITLE
#793 - mu: #! reader syntax

### DIFF
--- a/src/core/fasl/compile.l
+++ b/src/core/fasl/compile.l
@@ -57,6 +57,21 @@
          (93 . :fixnum)
          (94 . :float))))))
 
+(mu:intern core "%direct-to-hex"
+   (:lambda (direct)
+     ((:lambda (repr)
+        (mu:cdr
+           (mu:fix
+            (:lambda (loop)
+              ((:lambda (index str)
+                 (:if (mu:less-than index 8)
+                      (mu:cons (mu:add index 1) (core:%format () "~A~X" `(,str ,(mu:svref repr index))))
+                      loop))
+               (mu:car loop)
+               (mu:cdr loop)))
+           '(0 . ""))))
+      (mu:repr direct))))
+           
 (mu:intern core "%fasl-direct-compiler"
    (:lambda (tag stream)
      (core:%format stream "0 8" `())

--- a/src/core/format.l
+++ b/src/core/format.l
@@ -36,7 +36,7 @@
      ((:lambda (fx)
        (:if (core:fixnump fx)
             (:if (mu:eq 0 fx)
-                 (core:write "0" () dest)
+                 (core:write "00" () dest)
                  ((:lambda (str-stream)
                      (mu:fix
                       (:lambda (n)


### PR DESCRIPTION
add support for #! reader

docs: no change
tests: no change
srcs: tweak core format hex output and add repr to hex string function to core/fasl