### PR TITLE
#817 - test: fix core:typep reference

### DIFF
--- a/tests/performance/namespaces/core/vector
+++ b/tests/performance/namespaces/core/vector
@@ -1,5 +1,5 @@
 (core:make-vector '(1 2 3))
-(core:%core-type-p (core:make-vector '(1 2 3)))
+(core:%typep (core:make-vector '(1 2 3)))
 (core:vector-slice (core:make-vector '(1 2 3)) 1 2)
 (core:vector-length (core:make-vector '(1 2 3)))
 (core:vector-ref (core:make-vector '(1 2 3)) 1)


### PR DESCRIPTION
somehow missed a symbol name change in the performance tests

docs: no change
tests: fix performance vector test reference to core:%typep
srcs: no change 