### PR TITLE
#815 - core: apply generic functions

### DIFF
--- a/src/core/apply.l
+++ b/src/core/apply.l
@@ -89,45 +89,51 @@
 ;;;
 (mu:intern core "%compile-funcall"
    (:lambda (function-form arg-list env)
-     (:if (core:consp function-form)
-          ((:lambda (function)
-             (:if (core:%or (core:functionp function) (core:consp function))
-                  (:if (core:functionp function)
-                       (:if (core:%closurep function)
-                            `(,core:%apply
-                              ,function
-                              ,(core:%closure-prop :mu function)
-                              ,(core:%compile-lambda-arg-list function arg-list env))
-                            `(,mu:apply ,function ,(core:%compile-arg-list arg-list env)))
-                  `(mu:apply ,function ,(core:%compile-arg-list arg-list env)))
-             (core:raise function 'core:%compile-funcall "not a function designator")))
-           (core:%compile function-form env))
-          (:if (mu:boundp function-form)
+     (:if (core:%genericp function-form)
+          `(core:%apply ,function ,(core:%compile-arg-list arg-list env))
+          (:if (core:consp function-form)
                ((:lambda (function)
-                  (:if (core:functionp function)
-                       (:if (core:%closurep function)
-                            `(,core:%apply
-                              ,function
-                              ,(core:%closure-prop :mu function)
-                              ,(core:%compile-lambda-arg-list function arg-list env))
+                  (:if (core:%or (core:functionp function) (core:consp function))
+                       (:if (core:functionp function)
+                            (:if (core:%closurep function)
+                                 `(,core:%apply
+                                   ,function
+                                   ,(core:%closure-prop :mu function)
+                                   ,(core:%compile-lambda-arg-list function arg-list env))
+                                 `(,mu:apply ,function ,(core:%compile-arg-list arg-list env)))
                             `(mu:apply ,function ,(core:%compile-arg-list arg-list env)))
                        (core:raise function 'core:%compile-funcall "not a function designator")))
-                (mu:symbol-value function-form))
-               `(,core:apply ,function-form ,(core:%compile-arg-list arg-list env))))))
+                (core:%compile function-form env))
+               (:if (mu:boundp function-form)
+                    ((:lambda (function)
+                       (:if (core:%genericp function)
+                            `(core:%apply-generic ,function ,(core:%compile-arg-list arg-list env))
+                            (:if (core:functionp function)
+                                 (:if (core:%closurep function)
+                                      `(,core:%apply
+                                        ,function
+                                        ,(core:%closure-prop :mu function)
+                                        ,(core:%compile-lambda-arg-list function arg-list env))
+                                      `(mu:apply ,function ,(core:%compile-arg-list arg-list env)))
+                                 (core:raise function 'core:%compile-funcall "not a function designator"))))
+                     (mu:symbol-value function-form))
+                    `(,core:apply ,function-form ,(core:%compile-arg-list arg-list env)))))))
 
 ;;;
 ;;; apply 
 ;;;
 (mu:intern core "apply"
    (:lambda (function arg-list)
-     (:if (core:functionp function)
-          (:if (core:%closurep function)
-               (core:%apply
-                function
-                (core:%closure-prop :mu function)
-                (mu:eval (core:%compile-lambda-arg-list function arg-list ())))
-               (mu:apply function arg-list))
-          (core:raise function 'core:apply "not a function designator"))))
+     (:if (core:%genericp function)
+          (core:%apply-generic function arg-list)
+          (:if (core:functionp function)
+               (:if (core:%closurep function)
+                    (core:%apply
+                     function
+                     (core:%closure-prop :mu function)
+                     (mu:eval (core:%compile-lambda-arg-list function arg-list ())))
+                    (mu:apply function arg-list))
+               (core:raise function 'core:apply "not a function designator")))))
 
 (mu:intern core "%apply"
    (:lambda (closure frame arg-list-form)

--- a/tests/regression/namespaces/common/fixnum
+++ b/tests/regression/namespaces/common/fixnum
@@ -2,6 +2,14 @@
 (common:max 3)	3
 (common:min 1 2 -1 3)	-1
 (common:max 1 2 -1 3)	3
+(1+ 1)	2
+(1- 1)	0
+(1+ 1.0)	2.0000
+(1- 1.0)	0.0000
+(core:apply 1+ '(1))	2
+(core:apply 1- '(1))	0
+(core:apply 1+ '(1.0))	2.0000
+(core:apply 1- '(1.0))	0.0000
 (core:%apply-generic 1+ '(1))	2
 (core:%apply-generic 1- '(1))	0
 (core:%apply-generic 1+ '(1.0))	2.0000


### PR DESCRIPTION
generic functions now appliable

docs: no change
tests: expand core generics tests
srcs: core: allow generics to be applied