### PR TITLE
825 - mu: review native function implementation

### DIFF
--- a/src/mu_runtime/core/core.rs
+++ b/src/mu_runtime/core/core.rs
@@ -9,6 +9,7 @@ use {
             apply::CoreFunction as _,
             compile::CoreFunction as _,
             config::CoreFunction as _,
+            direct::DirectTag,
             env::Env,
             exception::{self, CoreFunction as _, Exception},
             frame::{CoreFunction as _, Frame},
@@ -234,10 +235,8 @@ impl Core {
         for (index, desc) in CORE_FUNCTIONS.iter().enumerate() {
             let (name, nreqs, _fn) = desc;
 
-            let vec = vec![env.mu_ns, Fixnum::with_or_panic(index)];
-
-            let fn_vec = Vector::from(vec).evict(env);
-            let func = Function::new((*nreqs).into(), fn_vec).evict(env);
+            let fn_ = DirectTag::cons(env.mu_ns, Fixnum::with_or_panic(index)).unwrap();
+            let func = Function::new((*nreqs).into(), fn_).evict(env);
 
             Namespace::intern_static(env, env.mu_ns, (*name).into(), func).unwrap();
         }
@@ -255,9 +254,8 @@ impl Core {
                     if let Some(functions) = feature.functions {
                         for (index, desc) in functions.iter().enumerate() {
                             let (name, nreqs, _fn) = *desc;
-                            let vec = vec![ns, Fixnum::with_or_panic(index)];
-                            let fn_vec = Vector::from(vec).evict(env);
-                            let func = Function::new((nreqs).into(), fn_vec).evict(env);
+                            let fn_ = DirectTag::cons(ns, Fixnum::with_or_panic(index)).unwrap();
+                            let func = Function::new((nreqs).into(), fn_).evict(env);
 
                             Namespace::intern_static(env, ns, (*name).into(), func).unwrap();
                         }

--- a/src/mu_runtime/types/function.rs
+++ b/src/mu_runtime/types/function.rs
@@ -14,7 +14,7 @@ use crate::{
         types::{Tag, TagType, Type},
     },
     streams::write::Write as _,
-    types::{fixnum::Fixnum, symbol::Symbol, vector::Vector},
+    types::{cons::Cons, fixnum::Fixnum, symbol::Symbol, vector::Vector},
 };
 
 use futures::executor::block_on;
@@ -22,7 +22,7 @@ use futures::executor::block_on;
 #[derive(Copy, Clone)]
 pub struct Function {
     pub arity: Tag, // fixnum # of required arguments
-    pub form: Tag,  // list or vector
+    pub form: Tag,  // dotted pair or list
 }
 
 pub trait Gc {
@@ -167,36 +167,44 @@ impl Function {
                 let form = Function::form(env, func);
 
                 let desc = match form.type_of() {
-                    Type::Cons | Type::Null => (
+                    Type::Null => (
                         "null".to_string(),
-                        ":lambda".to_string(),
+                        "lambda".to_string(),
                         format!("{:x}", form.as_u64()),
                     ),
-                    Type::Vector => {
-                        let ns = Vector::ref_(env, form, 0).unwrap();
-                        let offset = Vector::ref_(env, form, 1).unwrap();
+                    Type::Cons => match Cons::cdr(env, form).type_of() {
+                        Type::Null | Type::Cons => (
+                            "null".to_string(),
+                            ":lambda".to_string(),
+                            format!("{:x}", form.as_u64()),
+                        ),
+                        Type::Fixnum => {
+                            let ns = Cons::car(env, form);
+                            let offset = Cons::cdr(env, form);
 
-                        let ns_ref = block_on(env.ns_map.read());
-                        let (_, _, ref namespace) = ns_ref[Namespace::index_of(env, ns)];
+                            let ns_ref = block_on(env.ns_map.read());
+                            let (_, _, ref namespace) = ns_ref[Namespace::index_of(env, ns)];
 
-                        let fn_name = match namespace {
-                            Namespace::Static(static_) => match static_.functions {
-                                Some(functions) => {
-                                    functions[Fixnum::as_i64(offset) as usize].0.to_string()
-                                }
-                                None => "<undef>".to_string(),
-                            },
-                            _ => panic!(),
-                        };
+                            let fn_name = match namespace {
+                                Namespace::Static(static_) => match static_.functions {
+                                    Some(functions) => {
+                                        functions[Fixnum::as_i64(offset) as usize].0.to_string()
+                                    }
+                                    None => "<undef>".to_string(),
+                                },
+                                _ => panic!(),
+                            };
 
-                        (Namespace::name(env, ns).unwrap(), ":native".into(), fn_name)
-                    }
+                            (Namespace::name(env, ns).unwrap(), "native".into(), fn_name)
+                        }
+                        _ => panic!(),
+                    },
                     _ => panic!(),
                 };
 
                 env.write_string(
                     format!(
-                        "#<:function :{} [{}, req:{nreq}, form:{}]>",
+                        "#<:function :{} [type:{}, req:{nreq}, form:{}]>",
                         desc.0, desc.1, desc.2
                     )
                     .as_str(),

--- a/tests/regression/namespaces/mu/core
+++ b/tests/regression/namespaces/mu/core
@@ -27,8 +27,8 @@
 (mu:view #(:t 1 2))	#(:t 2 :t)
 (mu:view #s(:foo 1 2))	#(:t :foo #(:t 1 2))
 (mu:view 'a)	#(:t "" a :UNBOUND)
-(mu:view 'mu:eq)	#(:t "mu" eq #<:function :mu [:native, req:2, form:eq]>)
-(mu:view mu:eq)	#(:t 2 #(:t mu 0))
+(mu:view 'mu:eq)	#(:t "mu" eq #<:function :mu [type:native, req:2, form:eq]>)
+(mu:view mu:eq)	#(:t 2 (mu . 0))
 (mu:view mu:*standard-input*)	#(:t 0 :input :nil)
 (mu:with-exception (:lambda (cond obj) (mu:write cond () mu:*standard-output*)) (:lambda () (mu:div 1 1)))	1
 (mu:unrepr (mu:repr :t))	:t


### PR DESCRIPTION
use a dotted pair for native functions, tweak function write output format

docs: no change
tests: adjust to new function write output format, saves a lot of vectors, and maybe some perf time
srcs: rework function representation