### PR TITLE
#840 - core: performance improvement

### DIFF
--- a/src/core/compile.l
+++ b/src/core/compile.l
@@ -198,7 +198,7 @@
                                    ,function
                                    ,(core:%closure-prop :mu function)
                                    ,(core:%compile-lambda-arg-list function arg-list env))
-                                 `(,mu:apply ,function ,(core:%compile-arg-list arg-list env)))
+                                 `(mu:apply ,function ,(core:%compile-arg-list arg-list env)))
                             `(mu:apply ,function ,(core:%compile-arg-list arg-list env)))
                        (core:%raise function 'core:%compile-funcall "not a function designator")))
                 (core:%compile function-form env))
@@ -208,14 +208,14 @@
                             `(core:%apply-generic ,function ,(core:%compile-arg-list arg-list env))
                             (:if (core:functionp function)
                                  (:if (core:%closurep function)
-                                      `(,core:%apply
+                                      `(core:%apply
                                         ,function
                                         ,(core:%closure-prop :mu function)
                                         ,(core:%compile-lambda-arg-list function arg-list env))
                                       `(mu:apply ,function ,(core:%compile-arg-list arg-list env)))
                                  (core:%raise function 'core:%compile-funcall "not a function designator"))))
                      (mu:symbol-value function-form))
-                    `(,core:apply ,function-form ,(core:%compile-arg-list arg-list env)))))))
+                    `(core:apply ,function-form ,(core:%compile-arg-list arg-list env)))))))
 
 (mu:intern core "%compile"
    (:lambda (form env)

--- a/src/core/generic.l
+++ b/src/core/generic.l
@@ -26,8 +26,9 @@
 (mu:intern core "%make-generic"
    (:lambda (name impls)
      (core:%make-type "%generic"
-        `(,(mu:cons :name name)
-          ,(mu:cons :impls impls)))))
+          (core:%list2
+           (mu:cons :name name)
+           (mu:cons :impls impls)))))
 
 (mu:intern core "%genericp"
    (:lambda (type)

--- a/src/core/list.l
+++ b/src/core/list.l
@@ -17,7 +17,7 @@
              (:if list
                   (mu:cons
                    (mu:cdr list)
-                   (core:apply function (mu:cons (mu:car list) (mu:cons acc ()))))
+                   (core:apply function (core:%list2 (mu:car list) acc)))
                   arg))
            (mu:car arg)
            (mu:cdr arg)))
@@ -33,16 +33,10 @@
                   arg
                   (mu:cons
                    nth
-                   (core:apply function (mu:cons (mu:nth nth list) (mu:cons acc ()))))))
+                   (core:apply function (core:%list2 (mu:nth nth list) acc)))))
            (mu:sub (mu:car arg) 1)
            (mu:cdr arg)))
        (mu:cons (mu:length list) init)))))
-
-#|
-(mu:intern core "%foldr"
-   (:lambda (function init list)
-(core:%foldl function init (core:%reverse list))))
-|#
 
 ;;;
 ;;; maps

--- a/src/core/macro.l
+++ b/src/core/macro.l
@@ -16,7 +16,7 @@
 
 (mu:intern core "%compile-macro-call"
    (:lambda (macro-symbol arg-list env)
-     (core:%compile (core:macroexpand `(,macro-symbol ,@arg-list) ()) env)))
+     (core:%compile (core:macroexpand (mu:cons macro-symbol arg-list) ()) env)))
 
 ;;;
 ;;; functions

--- a/src/core/module.l
+++ b/src/core/module.l
@@ -35,7 +35,7 @@
    (:lambda (path lang)
      (:if (core:stringp path)
           (:if (mu:eq :core lang)
-               (core:load-file path)
+               (core:load path)
                ((:lambda (stream)
                   (mu:fix
                    (:lambda (loop)
@@ -44,9 +44,9 @@
                           ((:lambda (form)
                              (:if (mu:eq core:%eof% form)
                                   core:%eof%
-                                  ((:lambda ()
+                                  (core:%prog2
                                     (mu:eval (mu:compile form))
-                                    (core:null loop)))))
+                                    (core:null loop))))
                            (mu:read stream () core:%eof%))))
                    ()))
                 (mu:open :file :input path :t)))

--- a/src/core/quasi.l
+++ b/src/core/quasi.l
@@ -66,7 +66,7 @@
    (:lambda (expr recur)
      ((:lambda (syntax-map)
         ((:lambda (type-function)
-            (mu:apply type-function `(,(mu:cdr expr))))
+            (mu:apply type-function (core:%list (mu:cdr expr))))
          (core:%quasi-map-func (mu:car expr) syntax-map)))
      `(,(mu:cons :basic (:lambda (form) (core:%quote (core:%list form))))
         ,(mu:cons :comma (:lambda (form) `(mu:cons ,form ())))

--- a/src/core/read-macro.l
+++ b/src/core/read-macro.l
@@ -84,7 +84,7 @@
                          (core:%make-vector
                           (mu:make-vector :byte (core:%reverse (mu:cons byte loop)))
                           ()
-                          `(,(mu:add length (mu:mul 8 (mu:length loop))))))
+                          (core:%list (mu:add length (mu:mul 8 (mu:length loop))))))
                        (mu:car byte-descriptor)
                        (mu:cdr byte-descriptor))
                       (mu:cons byte-descriptor loop)))

--- a/src/core/stream.l
+++ b/src/core/stream.l
@@ -6,9 +6,9 @@
 ;;;
 
 ;;;
-;;; load-file
+;;; load
 ;;;
-(mu:intern core "load-file"
+(mu:intern core "load"
    (:lambda (path)
      (:if (core:stringp path)
           ((:lambda (stream)
@@ -19,13 +19,13 @@
                      ((:lambda (form)
                         (:if (mu:eq form core:%eof%)
                              core:%eof%
-                             ((:lambda ()
+                             (core:%prog2
                                 (mu:eval (core:compile form))
-                                (core:null loop)))))
+                                (core:null loop))))
                       (core:read stream () core:%eof%))))
               ()))
            (mu:open :file :input path :t))
-          (core:%raise path 'core:load-file "not a file path"))
+          (core:%raise path 'core:load "not a file path"))
      :t))
 
 ;;;

--- a/src/core/symbol-macro.l
+++ b/src/core/symbol-macro.l
@@ -12,16 +12,6 @@
   (:lambda (name)
       (mu:eq #\: (mu:svref name 0))))
 
-(mu:intern core "%read-symbol-scope"
-  (:lambda (name)
-     ((:lambda (colon)
-        (:if (core:null colon)
-             :extern
-             (:if (mu:eq #\: (mu:svref name (mu:add 1 colon)))
-                  :intern
-                  :extern)))
-        (core:%string-position #\: name))))
-
 (mu:intern core "%read-symbol-ns"
   (:lambda (name)
     ((:lambda (colon)
@@ -90,5 +80,5 @@
            (mu:intern core:*symbol-macros/* (mu:symbol-name symbol) form)
            (core:%raise symbol 'core:define-symbol-macro "not a symbol"))))
 
-;;; (core:define-symbol-macro 't :t)
-;;; (core:define-symbol-macro 'nil :nil)
+(core:define-symbol-macro 't :t)
+(core:define-symbol-macro 'nil :nil)

--- a/src/core/symbol.l
+++ b/src/core/symbol.l
@@ -30,17 +30,3 @@
           (mu:write (mu:add counter 1) () core:%gensym-counter%)
           (mu:make-symbol (core:%format () "g~X" (mu:cons counter ()))))
        (mu:read core:%gensym-counter% () ()))))
-
-#|
-(mu:intern core "%genkey"
-   (:lambda (prefix)
-      (:if (core:%or (core:null prefix) (core:charp prefix))
-           ((:lambda (counter)
-              (mu:write (mu:add counter 1) () core:%gensym-counter%)
-              (core:%make-keyword
-               (:if (core:charp prefix)
-                    (core:%format () "~A~X" (core:%list2 prefix counter))
-                    (core:%format () "<~X>" (mu:cons counter ())))))
-            (mu:read core:%gensym-counter% () ()))
-(core:%raise name 'core:%genkey "not a legal prefix"))))
-|#

--- a/src/core/type.l
+++ b/src/core/type.l
@@ -216,8 +216,8 @@
                     ((:lambda (symbol)
                        (:if symbol
                             symbol
-                            ((:lambda ()
+                            (core:%prog2
                                (mu:write (mu:symbol-name type) () core:%quote%)
-                               (mu:read core:%quote% :t ())))))
+                               (mu:read core:%quote% :t ()))))
                      (mu:find mu:*null/* (mu:symbol-name type))))))
        (mu:type-of value))))

--- a/src/core/vector.l
+++ b/src/core/vector.l
@@ -200,7 +200,7 @@
               ((:lambda (nth list)
                  (:if (core:fixnump nth)
                      (:if (mu:less-than nth (mu:vector-length vector))
-                          (mu:cons (mu:add 1 nth) (mu:append `(,list ,(mu:cons (mu:svref vector nth) ()))))
+                          (mu:cons (mu:add 1 nth) (core:%append `(,list ,(mu:cons (mu:svref vector nth) ()))))
                           (mu:cons () list))
                      loop))
                (mu:car loop)
@@ -280,9 +280,9 @@
                    (mu:fix
                     (:lambda (index)
                       (:if (mu:less-than index (mu:vector-length string))
-                           ((:lambda ()
+                           (core:%prog2
                               (mu:write-char (mu:svref string index) concat)
-                              (mu:add index 1)))
+                              (mu:add index 1))
                            index))
                     0)
                    (mu:cdr list))

--- a/src/mu_runtime/types/function.rs
+++ b/src/mu_runtime/types/function.rs
@@ -175,7 +175,7 @@ impl Function {
                     Type::Cons => match Cons::cdr(env, form).type_of() {
                         Type::Null | Type::Cons => (
                             "null".to_string(),
-                            ":lambda".to_string(),
+                            "lambda".to_string(),
                             format!("{:x}", form.as_u64()),
                         ),
                         Type::Fixnum => {
@@ -204,7 +204,7 @@ impl Function {
 
                 env.write_string(
                     format!(
-                        "#<:function :{} [type{}, req:{nreq}, form:{}]>",
+                        "#<:function :{} [type:{}, req:{nreq}, form:{}]>",
                         desc.0, desc.1, desc.2
                     )
                     .as_str(),


### PR DESCRIPTION
speed up/slim down core operations, get mu function write output format right

docs: no change
tests: saved about 2500 bytes in core perf, nominal speed increase, dropped about 120 conses in startup
srcs: convert lots of backquoted forms to conses