### PR TITLE
#845 - runtime: embrace smol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,14 @@ bench = false
 
 [features]
 default = [ "env", "procinfo", "nix", "std", "sysinfo" ]
-env = []        # needed for testing, common
+env = []           # needed for testing, common
 ffi = []
 nix = []
 procinfo = []
-prof = []         # profiling
+prof = []
 semispace = []
 std = []
-sysinfo = []      # not for macos
+sysinfo = []       # not for macos
 
 [profile.dev]
 opt-level = 0
@@ -38,8 +38,7 @@ codegen-units = 1
 inherits = "release"
 
 [dependencies]
-async-std = "1.13"
-futures = { version = "0.3", features = [ "executor", "thread-pool" ]}
+futures-lite = "2.6"
 futures-locks = "0.7"
 lazy_static = "1.5"
 memmap = "0.7"
@@ -48,6 +47,7 @@ nix = {version = "0.29", features = [ "feature" ]}
 num_enum = "0.7"
 page_size = "0.6"
 perf_monitor = "0.2"
+smol = "2.0"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
 sysinfo_dot_h = "0.2"

--- a/src/mu_runtime/core/core.rs
+++ b/src/mu_runtime/core/core.rs
@@ -37,9 +37,9 @@ use {
     std::collections::HashMap,
 };
 
-use {futures::executor::block_on, futures_locks::RwLock};
+use {futures_lite::future::block_on, futures_locks::RwLock};
 
-pub const VERSION: &str = "0.2.5";
+pub const VERSION: &str = "0.2.6";
 
 pub type CoreFn = fn(&Env, &mut Frame) -> exception::Result<()>;
 pub type CoreFnDef = (&'static str, u16, CoreFn);

--- a/src/mu_runtime/core/dynamic.rs
+++ b/src/mu_runtime/core/dynamic.rs
@@ -9,7 +9,7 @@
 //!    frame_ref
 use crate::core::{env::Env, type_image::TypeImage, types::Tag};
 
-use {futures::executor::block_on, futures_locks::RwLock};
+use {futures_lite::future::block_on, futures_locks::RwLock};
 
 pub struct Dynamic {
     pub dynamic: RwLock<Vec<(u64, usize)>>,

--- a/src/mu_runtime/core/exception.rs
+++ b/src/mu_runtime/core/exception.rs
@@ -5,7 +5,7 @@
 //!    Condition
 //!    Exception
 //!    `Result<Exception>`
-use futures::executor::block_on;
+use futures_lite::future::block_on;
 use {
     crate::{
         core::{

--- a/src/mu_runtime/core/frame.rs
+++ b/src/mu_runtime/core/frame.rs
@@ -25,7 +25,7 @@ use crate::{
 #[cfg(feature = "prof")]
 use crate::features::{feature::Feature, prof::Prof};
 
-use {futures::executor::block_on, futures_locks::RwLock};
+use {futures_lite::future::block_on, futures_locks::RwLock};
 
 pub struct Frame {
     pub argv: Vec<Tag>,

--- a/src/mu_runtime/core/gc_context.rs
+++ b/src/mu_runtime/core/gc_context.rs
@@ -22,7 +22,7 @@ use crate::{
     vectors::vector::Gc as _,
 };
 
-use futures::executor::block_on;
+use futures_lite::future::block_on;
 
 pub struct GcContext<'a> {
     pub heap_ref: &'a mut futures_locks::RwLockWriteGuard<HeapAllocator>,

--- a/src/mu_runtime/core/heap.rs
+++ b/src/mu_runtime/core/heap.rs
@@ -15,7 +15,7 @@ use {
         },
         types::{cons::Cons, function::Function, struct_::Struct, symbol::Symbol, vector::Vector},
     },
-    futures::executor::block_on,
+    futures_lite::future::block_on,
     memmap,
     modular_bitfield::specifiers::{B11, B4},
     std::{

--- a/src/mu_runtime/core/namespace.rs
+++ b/src/mu_runtime/core/namespace.rs
@@ -16,7 +16,7 @@ use {
     std::{collections::HashMap, str},
 };
 
-use {futures::executor::block_on, futures_locks::RwLock};
+use {futures_lite::future::block_on, futures_locks::RwLock};
 
 #[derive(Clone)]
 pub struct Static {

--- a/src/mu_runtime/core/types.rs
+++ b/src/mu_runtime/core/types.rs
@@ -21,7 +21,7 @@ use {
     std::{convert::From, fmt},
 };
 
-use futures::executor::block_on;
+use futures_lite::future::block_on;
 
 // tag storage classes
 #[derive(Copy, Clone)]

--- a/src/mu_runtime/features/env.rs
+++ b/src/mu_runtime/features/env.rs
@@ -20,7 +20,7 @@ use {
             vector::Vector,
         },
     },
-    futures::executor::block_on,
+    futures_lite::future::block_on,
     futures_locks::RwLock,
     std::collections::HashMap,
 };

--- a/src/mu_runtime/features/heaps/allocator.rs
+++ b/src/mu_runtime/features/heaps/allocator.rs
@@ -17,7 +17,7 @@ use {
     std::fmt,
 };
 
-use futures::executor::block_on;
+use futures_lite::future::block_on;
 
 #[bitfield]
 #[repr(align(8))]

--- a/src/mu_runtime/features/heaps/bump_allocator.rs
+++ b/src/mu_runtime/features/heaps/bump_allocator.rs
@@ -12,7 +12,7 @@ use {
     },
 };
 
-use {futures::executor::block_on, futures_locks::RwLock};
+use {futures_lite::future::block_on, futures_locks::RwLock};
 
 #[derive(Debug)]
 pub struct BumpAllocator {

--- a/src/mu_runtime/features/heaps/image.rs
+++ b/src/mu_runtime/features/heaps/image.rs
@@ -4,7 +4,7 @@
 //! image management
 #![allow(dead_code)]
 use crate::core::env::Env;
-use futures::executor::block_on;
+use futures_lite::future::block_on;
 
 pub struct Image {
     image: Vec<u8>,

--- a/src/mu_runtime/features/heaps/stack_allocator.rs
+++ b/src/mu_runtime/features/heaps/stack_allocator.rs
@@ -4,7 +4,7 @@
 //! env heap
 #![allow(dead_code)]
 use crate::heaps::allocator::{AllocTypeInfo, AllocatorImageInfo};
-use {futures::executor::block_on, futures_locks::RwLock};
+use {futures_lite::future::block_on, futures_locks::RwLock};
 
 #[derive(Debug)]
 pub struct StackAllocator {

--- a/src/mu_runtime/features/prof.rs
+++ b/src/mu_runtime/features/prof.rs
@@ -15,7 +15,7 @@ use crate::{
     types::{cons::Cons, fixnum::Fixnum, symbol::Symbol, vector::Vector},
 };
 use std::collections::HashMap;
-use {futures::executor::block_on, futures_locks::RwLock};
+use {futures_lite::future::block_on, futures_locks::RwLock};
 
 pub trait Prof {
     fn feature() -> Feature;

--- a/src/mu_runtime/features/semispace.rs
+++ b/src/mu_runtime/features/semispace.rs
@@ -23,7 +23,7 @@ use {
     },
 };
 
-use {futures::executor::block_on, futures_locks::RwLock};
+use {futures_lite::future::block_on, futures_locks::RwLock};
 
 pub trait SemiSpace {
     fn feature() -> Feature;

--- a/src/mu_runtime/lib.rs
+++ b/src/mu_runtime/lib.rs
@@ -53,7 +53,7 @@ mod streams;
 mod types;
 mod vectors;
 
-use futures::executor::block_on;
+use futures_lite::future::block_on;
 use {
     crate::{
         core::{

--- a/src/mu_runtime/streams/operator.rs
+++ b/src/mu_runtime/streams/operator.rs
@@ -14,11 +14,10 @@ use {
         streams::system::{StringDirection, SystemStream, SystemStreamBuilder},
         types::{stream::Stream, symbol::Symbol},
     },
-    async_std::{io::WriteExt, task},
     std::{io::Write, str},
 };
 
-use futures::executor::block_on;
+use futures_lite::{future::block_on, AsyncWriteExt};
 use futures_locks::RwLock;
 
 impl SystemStream {
@@ -56,7 +55,7 @@ impl SystemStream {
             Self::Reader(file) => drop(block_on(file.read())),
             Self::Writer(file) => {
                 let mut file = block_on(file.write());
-                let _unused = task::block_on(async { file.flush().await });
+                let _unused = block_on(async { file.flush().await });
 
                 drop(file)
             }

--- a/src/mu_runtime/types/cons.rs
+++ b/src/mu_runtime/types/cons.rs
@@ -21,7 +21,7 @@ use crate::{
     types::{fixnum::Fixnum, symbol::Symbol, vector::Vector},
 };
 
-use futures::executor::block_on;
+use futures_lite::future::block_on;
 
 #[derive(Copy, Clone)]
 pub struct Cons {

--- a/src/mu_runtime/types/function.rs
+++ b/src/mu_runtime/types/function.rs
@@ -17,7 +17,7 @@ use crate::{
     types::{cons::Cons, fixnum::Fixnum, symbol::Symbol, vector::Vector},
 };
 
-use futures::executor::block_on;
+use futures_lite::future::block_on;
 
 #[derive(Copy, Clone)]
 pub struct Function {

--- a/src/mu_runtime/types/namespace.rs
+++ b/src/mu_runtime/types/namespace.rs
@@ -21,7 +21,7 @@ use crate::{
     },
 };
 
-use futures::executor::block_on;
+use futures_lite::future::block_on;
 
 pub trait Gc {
     #[allow(dead_code)]

--- a/src/mu_runtime/types/stream.rs
+++ b/src/mu_runtime/types/stream.rs
@@ -16,7 +16,7 @@ use crate::{
     types::{char::Char, fixnum::Fixnum, symbol::Symbol, vector::Vector},
 };
 
-use futures::executor::block_on;
+use futures_lite::future::block_on;
 
 // stream struct
 pub struct Stream {

--- a/src/mu_runtime/types/struct_.rs
+++ b/src/mu_runtime/types/struct_.rs
@@ -17,7 +17,7 @@ use crate::{
     types::{cons::Cons, stream::Read, symbol::Symbol, vector::Vector},
 };
 
-use futures::executor::block_on;
+use futures_lite::future::block_on;
 
 // a struct is a vector with an arbitrary type keyword
 #[derive(Copy, Clone)]

--- a/src/mu_runtime/types/symbol.rs
+++ b/src/mu_runtime/types/symbol.rs
@@ -24,7 +24,7 @@ use {
     std::str,
 };
 
-use futures::executor::block_on;
+use futures_lite::future::block_on;
 
 lazy_static! {
     pub static ref UNBOUND: Tag = DirectTag::to_tag(0, DirectExt::Length(0), DirectType::Keyword);

--- a/src/mu_runtime/types/vector.rs
+++ b/src/mu_runtime/types/vector.rs
@@ -19,7 +19,7 @@ use {
             write::Write,
         },
     },
-    futures::executor::block_on,
+    futures_lite::future::block_on,
     std::str,
 };
 

--- a/src/mu_runtime/vectors/cache.rs
+++ b/src/mu_runtime/vectors/cache.rs
@@ -11,7 +11,7 @@ use {
         types::{fixnum::Fixnum, float::Float, vector::Vector},
         vectors::image::{VecImageType, VectorImageType},
     },
-    futures::executor::block_on,
+    futures_lite::future::block_on,
     futures_locks::RwLock,
     std::collections::HashMap,
 };

--- a/src/mu_runtime/vectors/image.rs
+++ b/src/mu_runtime/vectors/image.rs
@@ -19,7 +19,7 @@ use {
     std::str,
 };
 
-use futures::executor::block_on;
+use futures_lite::future::block_on;
 
 #[derive(Clone)]
 pub struct VectorImage {


### PR DESCRIPTION
replace async-std with smol

docs: no change
tests: no change, substantial decrease inn vmem run size
srcs: all async-std calls now smol in mu_runtime