### PR TITLE
#881 - core: environment object infrastructure

### DIFF
--- a/src/core/closure.l
+++ b/src/core/closure.l
@@ -15,33 +15,35 @@
 ;;;  (:env     . :listp)      closure captured environment
 ;;;  (:mu      . :func)       closure implementation function
 ;;;  (:arity   . :fixnum)     frame lambda number of required args
+;;;  (:lenv    . :listp)      compiled in lexical environment (symbol . (...))
 ;;;
 (core:%deftype "%closure"
     '((:require . :listp)
       (:rest    . :symbolp)
       (:arity   . :fixnum)
       (:mu      . :func)
-      (:env     . :listp)))
+      (:env     . :listp)
+      (:lenv    . :listp)))
 
 (mu:intern core "%closure-prop"
    (:lambda (prop function)
      (mu:cdr (core:%type-prop prop function))))
 
 (mu:intern core "%make-closure"
-   (:lambda (requires rest-sym form env)
+   (:lambda (requires rest-sym form env lenv)
      (core:%make-type "%closure"
        `(,(mu:cons :require   requires)
           ,(mu:cons :rest     rest-sym)
           ,(mu:cons :mu       (mu:compile form))
           ,(mu:cons :arity    (mu:sub (mu:length requires) (:if rest-sym 1 0)))
-          ,(mu:cons :env      env)))))
+          ,(mu:cons :env      env)
+          ,(mu:cons :lenv     lenv)))))
 
 (mu:intern core "%closurep"
    (:lambda (function)
      (:if (core:%typep function)
           (mu:eq '%closure (core:type-of function))
           ())))
-
 
 ;;;
 ;;; env deftype
@@ -96,7 +98,7 @@
                    ((:lambda (closure)
                       (core:%add-frame (core:%env-prop :name (mu:car env)) (core:%closure-prop :mu closure))
                       closure)
-                    (core:%make-closure (mu:car desc) (mu:cdr desc) `(:lambda ,(mu:car desc) ,@body) ())))                   
+                    (core:%make-closure (mu:car desc) (mu:cdr desc) `(:lambda ,(mu:car desc) ,@body) () ())))
                  (core:%mapcar
                   (:lambda (form)
                     (core:%compile form env))

--- a/src/core/common.l
+++ b/src/core/common.l
@@ -70,7 +70,7 @@
 ;;;
 (core:compile
  '(%defmacro progn (&rest body)
-     (:if (mu:less-than (mu:length body) 2)
+     (%if (mu:less-than (mu:length body) 2)
        (mu:car body)
        `((%lambda () ,@body)))))
 
@@ -89,7 +89,7 @@
 
 (core:compile
  '(%defmacro let* (binds &rest body)
-   (:if binds
+   (%if binds
        `(let (,(mu:car binds)) (let* ,(mu:cdr binds) ,@body))
        `(let () ,@body))))
 

--- a/src/core/compile.l
+++ b/src/core/compile.l
@@ -215,7 +215,9 @@
                                       `(mu:apply ,function ,(core:%compile-arg-list arg-list env)))
                                  (core:%raise function 'core:%compile-funcall "not a function designator"))))
                      (mu:symbol-value function-form))
-                    `(core:apply ,function-form ,(core:%compile-arg-list arg-list env)))))))
+                    (core:%raise function-form 'core:%compile-funcall "function symbol not bound"))))))
+
+     ;;; `(core:apply ,function-form ,(core:%compile-arg-list arg-list env)))))))
 
 (mu:intern core "%compile"
    (:lambda (form env)

--- a/src/core/macro.l
+++ b/src/core/macro.l
@@ -6,7 +6,8 @@
 ;;;
 (mu:intern core "%defmacro"
    (:lambda (symbol macro-function)
-      ((:lambda (symbol-ns symbol-name)
+     ;;; (core:%warn `(,symbol ,macro-function) "%defmacro")
+     ((:lambda (symbol-ns symbol-name)
          (:if (mu:eq symbol-ns mu:*null/*)
               (mu:intern core:*macros/* symbol-name macro-function)
               (core:%raise symbol-ns 'core:%defmacro "illegal symbol"))
@@ -16,7 +17,44 @@
 
 (mu:intern core "%compile-macro-call"
    (:lambda (macro-symbol arg-list env)
-     (core:%compile (core:macroexpand (mu:cons macro-symbol arg-list) ()) env)))
+     (core:%compile (core:macroexpand (mu:cons macro-symbol arg-list) env) env)))
+
+;;;
+;;; compile macro closure
+;;;
+(mu:intern core "%compile-macro-closure"
+   (:lambda (lambda body env)
+     (:if (core:%find-if (:lambda (el) (core:null (mu:eq :symbol (mu:type-of el)))) lambda)
+          (core:%raise lambda 'core:%compile-macro-closure "malformed macro lambda expression")
+          ((:lambda (desc)
+             ((:lambda (env)
+                ((:lambda (body)
+                   ((:lambda (closure)
+                      (core:%add-frame (core:%env-prop :name (mu:car env)) (core:%closure-prop :mu closure))
+                      closure)
+                    (core:%make-closure (mu:car desc) (mu:cdr desc) `(:lambda ,(mu:car desc) ,@body) () ())))
+                 (core:%mapcar
+                  (:lambda (form)
+                    (core:%compile form env))
+                  body)))
+              (mu:cons (core:%make-env (mu:length env) (mu:car desc) (core:gensym)) env)))
+          ((:lambda (desc)
+             (:if (core:%or (core:fixnump desc) (core:null body))
+                  (core:%list lambda)
+                  desc))
+           (core:%foldl
+            (:lambda (el acc)
+              (:if (core:numberp acc)
+                   (:if (mu:eq '&rest el)
+                        (:if (mu:eq (mu:length lambda) (mu:add 2 acc))
+                             (mu:cons
+                              `(,@(core:%dropr lambda 2) ,@(core:%dropl lambda (mu:sub (mu:length lambda) 1)))
+                              (mu:nth (mu:sub (mu:length lambda) 1) lambda))
+                             (core:%raise lambda 'core:%compile-macro-closure "rest botch"))
+                        (mu:add 1 acc))
+                   acc))
+            0
+            lambda))))))
 
 ;;;
 ;;; functions


### PR DESCRIPTION
augment core closure struct, don't allow core funcalls with unbound function symbols

docs: no change
tests: no change
srcs: amend core closure struct to capture a compile-time environment