### PR TITLE
#912 - core-sys: new config protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ The  *core-sys* binary is part of a release, found at `/opt/mu/bin/core-sys`.
 ```
 {
     "config": {
-    	"pages": 2048",
+    	"pages": "2048",
     	"gc-mode": "auto"
     },
     "rc": "core-sys.rc"

--- a/src/core-sys/src/config.rs
+++ b/src/core-sys/src/config.rs
@@ -6,6 +6,7 @@ use {
     std::path::PathBuf,
 };
 
+#[derive(Debug)]
 pub enum Config {
     Json(JsonValue),
     None,
@@ -42,8 +43,9 @@ impl Config {
 
     pub fn map(&self, key: &str) -> Option<String> {
         match self {
-            Config::Json(opts) => match opts[key] {
+            Config::Json(opts) => match &opts[key] {
                 JsonValue::Short(str) => Some(str.as_str().to_string()),
+                JsonValue::Object(obj) => Some(obj.dump()),
                 _ => None,
             },
             Config::None => None,

--- a/src/core-sys/src/env_.rs
+++ b/src/core-sys/src/env_.rs
@@ -15,9 +15,10 @@ pub struct Env_ {
 impl Env_ {
     pub fn new(config: Config) -> Self {
         let env = match config.map("config") {
-            Some(config) => {
-                Mu::make_env(&Mu::config(Some(config)).expect("core-sys: unable to allocate env"))
-            }
+            Some(config) => Mu::make_env(
+                &Mu::config(Some(config))
+                    .expect("core-sys: unable to allocate env from config {config:?}"),
+            ),
             None => Mu::make_env(&Mu::config(None).expect("core-sys: unable to allocate env")),
         };
 

--- a/src/mu/core/config.rs
+++ b/src/mu/core/config.rs
@@ -83,6 +83,11 @@ impl ConfigBuilder {
 
         self.npages = match npages.unwrap() {
             JsonValue::Number(n) => Some(n.integer as usize),
+            JsonValue::String(nstr) => Some(
+                (*(nstr.iter().collect::<String>()))
+                    .parse::<usize>()
+                    .unwrap(),
+            ),
             _ => panic!("pages: config string format"),
         };
 


### PR DESCRIPTION
Make core-sys obey the new config format

docs: amend README
tests: no change
srcs: make mu/core/config.rs more flexible about the page argument, core-sys now exports json config